### PR TITLE
✨ [FEATURE] Unit of work has been supported

### DIFF
--- a/sample/EasyRepository.Sample/Controllers/AuthorController.cs
+++ b/sample/EasyRepository.Sample/Controllers/AuthorController.cs
@@ -41,7 +41,7 @@ namespace EasyRepository.Sample.Controllers
                  AuthorId = Guid.NewGuid()
              });
              
-            await _unitOfWork.Repository.SaveChangesAsync();
+            await _unitOfWork.Repository.CompleteAsync();
             return Ok(entity);
         }
 

--- a/sample/EasyRepository.Sample/Controllers/AuthorController.cs
+++ b/sample/EasyRepository.Sample/Controllers/AuthorController.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EasyRepository.EFCore.Generic;
 
 namespace EasyRepository.Sample.Controllers
 {
@@ -16,21 +17,31 @@ namespace EasyRepository.Sample.Controllers
     public class AuthorController : ControllerBase
     {
         private readonly IRepository repository;
+        private readonly IUnitOfWork _unitOfWork;
 
-        public AuthorController(IRepository repository)
+        public AuthorController(IRepository repository, IUnitOfWork unitOfWork)
         {
             this.repository = repository;
+            _unitOfWork = unitOfWork;
         }
 
         [HttpPost]
         public async Task<IActionResult> AddAuthorAsync([FromBody] AuthorRequestDto dto)
         {
-            var entity = await repository.AddAsync<Author, Guid>(new Author
+            var entity = await _unitOfWork.Repository.AddAsync<Author, Guid>(new Author
             {
                 Name = dto.Name,
                 Surname = dto.Surname
-            }, default);
+            });
 
+             var book = await _unitOfWork.Repository.AddAsync<Book, Guid>(new Book
+             {
+                 Title = "Book 123",
+                 TotalPage = 124,
+                 AuthorId = Guid.NewGuid()
+             });
+             
+            await _unitOfWork.Repository.SaveChangesAsync();
             return Ok(entity);
         }
 

--- a/sample/EasyRepository.Sample/Controllers/BookController.cs
+++ b/sample/EasyRepository.Sample/Controllers/BookController.cs
@@ -16,7 +16,6 @@ namespace EasyRepository.Sample.Controllers
     public class BookController : ControllerBase
     {
         private readonly IRepository repository;
-
         public BookController(IRepository repository)
         {
             this.repository = repository;

--- a/sample/EasyRepository.Sample/Startup.cs
+++ b/sample/EasyRepository.Sample/Startup.cs
@@ -4,17 +4,13 @@ using EasyRepository.Sample.Context;
 using MarkdownDocumenting.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace EasyRepository.Sample
 {
@@ -31,12 +27,13 @@ namespace EasyRepository.Sample
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews();
-            services.ApplyEasyRepository<SampleDbContext>();
 
             services.AddDbContext<SampleDbContext>(options =>
             {
                 options.UseNpgsql(Configuration.GetConnectionString("DefaultConnection"));
             }, ServiceLifetime.Transient);
+            
+            services.ApplyEasyRepository<SampleDbContext>();
 
             services.AddSwaggerGen(options =>
             {

--- a/src/EasyRepository.EFCore.Abstractions/IRepository.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IRepository.cs
@@ -1654,5 +1654,19 @@ namespace EasyRepository.EFCore.Abstractions
         /// Returns <see cref="int"/>
         /// </returns>
         Task<int> CountAsync<TEntity, TFilter>(TFilter filter, CancellationToken cancellationToken = default) where TEntity : class, new() where TFilter : FilterBase;
+
+        /// <summary>
+        /// This method provides save changes for changes in current transaction
+        /// </summary>
+        void SaveChanges();
+        
+        /// <summary>
+        /// This method takes <see cref="CancellationToken"/> cancellation token in additional this method provides save changes for changes in current transactions
+        /// </summary>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        /// Task. <see cref="Task"/>
+        /// </returns>
+        Task SaveChangesAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/EasyRepository.EFCore.Abstractions/IRepository.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IRepository.cs
@@ -1658,7 +1658,7 @@ namespace EasyRepository.EFCore.Abstractions
         /// <summary>
         /// This method provides save changes for changes in current transaction
         /// </summary>
-        void SaveChanges();
+        void Complete();
         
         /// <summary>
         /// This method takes <see cref="CancellationToken"/> cancellation token in additional this method provides save changes for changes in current transactions
@@ -1667,6 +1667,6 @@ namespace EasyRepository.EFCore.Abstractions
         /// <returns>
         /// Task. <see cref="Task"/>
         /// </returns>
-        Task SaveChangesAsync(CancellationToken cancellationToken = default);
+        Task CompleteAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/EasyRepository.EFCore.Generic/IUnitOfWork.cs
+++ b/src/EasyRepository.EFCore.Generic/IUnitOfWork.cs
@@ -1,0 +1,11 @@
+﻿using EasyRepository.EFCore.Abstractions;
+
+namespace EasyRepository.EFCore.Generic;
+
+/// <summary>
+/// Abstraction of Unit Of Work pattern
+/// </summary>
+public interface IUnitOfWork
+{
+    IRepository Repository { get; }
+}

--- a/src/EasyRepository.EFCore.Generic/Repository.cs
+++ b/src/EasyRepository.EFCore.Generic/Repository.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EasyRepository.EFCore.Generic
 {
@@ -57,7 +58,7 @@ namespace EasyRepository.EFCore.Generic
         {
             entity.CreationDate = DateTime.UtcNow;
             await context.Set<TEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            //await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             return entity;
         }
 
@@ -137,6 +138,16 @@ namespace EasyRepository.EFCore.Generic
         {
             int count = await context.Set<TEntity>().ApplyFilter(filter).CountAsync(cancellationToken).ConfigureAwait(false);
             return count;
+        }
+
+        public void SaveChanges()
+        {
+            context.SaveChanges();
+        }
+
+        public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private Expression<Func<TEntity, bool>> GenerateExpression<TEntity>(object id)

--- a/src/EasyRepository.EFCore.Generic/Repository.cs
+++ b/src/EasyRepository.EFCore.Generic/Repository.cs
@@ -15,11 +15,11 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace EasyRepository.EFCore.Generic
 {
     /// <summary>
-    /// This class includes implementations of repository functions
+    /// This class contains implementations of repository functions
     /// </summary>
-    internal class Repository : IRepository
+    internal sealed class Repository : IRepository
     {
-        private readonly DbContext context;
+        private readonly DbContext _context;
 
         /// <summary>
         /// Ctor
@@ -29,130 +29,122 @@ namespace EasyRepository.EFCore.Generic
         /// </param>
         public Repository(DbContext context)
         {
-            this.context = context;
+            this._context = context;
         }
 
-        public virtual TEntity Add<TEntity>(TEntity entity) where TEntity : class, new()
+        public TEntity Add<TEntity>(TEntity entity) where TEntity : class, new()
         {
-            context.Set<TEntity>().Add(entity);
-            context.SaveChanges();
+            _context.Set<TEntity>().Add(entity);
             return entity;
         }
 
-        public virtual TEntity Add<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public TEntity Add<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.CreationDate = DateTime.UtcNow;
-            context.Set<TEntity>().Add(entity);
-            context.SaveChanges();
+            _context.Set<TEntity>().Add(entity);
             return entity;
         }
 
-        public virtual async Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            await context.Set<TEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _context.Set<TEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
             return entity;
         }
 
-        public virtual async Task<TEntity> AddAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public async Task<TEntity> AddAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.CreationDate = DateTime.UtcNow;
-            await context.Set<TEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
-            //await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _context.Set<TEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
             return entity;
         }
 
-        public virtual IEnumerable<TEntity> AddRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class, new()
+        public IEnumerable<TEntity> AddRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class, new()
         {
-            context.Set<TEntity>().AddRange(entities);
-            context.SaveChanges();
+            _context.Set<TEntity>().AddRange(entities);
             return entities;
         }
 
-        public virtual IEnumerable<TEntity> AddRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public IEnumerable<TEntity> AddRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entities.ToList().ForEach(x => x.CreationDate = DateTime.UtcNow);
-            context.Set<TEntity>().AddRange(entities);
-            context.SaveChanges();
+            _context.Set<TEntity>().AddRange(entities);
             return entities;
         }
 
-        public virtual async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            await context.Set<TEntity>().AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _context.Set<TEntity>().AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
             return entities;
         }
 
-        public virtual async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entities.ToList().ForEach(x => x.CreationDate = DateTime.UtcNow);
-            await context.Set<TEntity>().AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _context.Set<TEntity>().AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
             return entities;
         }
 
-        public virtual bool Any<TEntity>(Expression<Func<TEntity, bool>> anyExpression) where TEntity : class, new()
+        public bool Any<TEntity>(Expression<Func<TEntity, bool>> anyExpression) where TEntity : class, new()
         {
-            return context.Set<TEntity>().Any(anyExpression);
+            return _context.Set<TEntity>().Any(anyExpression);
         }
 
-        public virtual async Task<bool> AnyAsync<TEntity>(Expression<Func<TEntity, bool>> anyExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<bool> AnyAsync<TEntity>(Expression<Func<TEntity, bool>> anyExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            bool result = await context.Set<TEntity>().AnyAsync(anyExpression, cancellationToken).ConfigureAwait(false);
+            bool result = await _context.Set<TEntity>().AnyAsync(anyExpression, cancellationToken).ConfigureAwait(false);
             return result;
         }
 
-        public virtual int Count<TEntity>() where TEntity : class, new()
+        public int Count<TEntity>() where TEntity : class, new()
         {
-            return context.Set<TEntity>().Count();
+            return _context.Set<TEntity>().Count();
         }
 
-        public virtual int Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression) where TEntity : class, new()
+        public int Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression) where TEntity : class, new()
         {
-            return context.Set<TEntity>().Where(whereExpression).Count();
+            return _context.Set<TEntity>().Where(whereExpression).Count();
         }
 
-        public virtual async Task<int> Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<int> Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            int count = await context.Set<TEntity>().Where(whereExpression).CountAsync(cancellationToken).ConfigureAwait(false);
+            int count = await _context.Set<TEntity>().Where(whereExpression).CountAsync(cancellationToken).ConfigureAwait(false);
             return count;
         }
 
-        public virtual int Count<TEntity, TFilter>(TFilter filter)
+        public int Count<TEntity, TFilter>(TFilter filter)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
-            return context.Set<TEntity>().ApplyFilter(filter).Count();
+            return _context.Set<TEntity>().ApplyFilter(filter).Count();
         }
 
-        public virtual async Task<int> CountAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<int> CountAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            int count = await context.Set<TEntity>().CountAsync(cancellationToken).ConfigureAwait(false);
+            int count = await _context.Set<TEntity>().CountAsync(cancellationToken).ConfigureAwait(false);
             return count;
         }
 
-        public virtual async Task<int> CountAsync<TEntity, TFilter>(TFilter filter, CancellationToken cancellationToken = default)
+        public async Task<int> CountAsync<TEntity, TFilter>(TFilter filter, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
-            int count = await context.Set<TEntity>().ApplyFilter(filter).CountAsync(cancellationToken).ConfigureAwait(false);
+            int count = await _context.Set<TEntity>().ApplyFilter(filter).CountAsync(cancellationToken).ConfigureAwait(false);
             return count;
         }
 
         public void SaveChanges()
         {
-            context.SaveChanges();
+            _context.SaveChanges();
         }
 
         public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
         {
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private Expression<Func<TEntity, bool>> GenerateExpression<TEntity>(object id)
         {
-            var type = context.Model.FindEntityType(typeof(TEntity));
+            var type = _context.Model.FindEntityType(typeof(TEntity));
             string pk = type.FindPrimaryKey().Properties.Select(s => s.Name).FirstOrDefault();
             Type pkType = type.FindPrimaryKey().Properties.Select(p => p.ClrType).FirstOrDefault();
 
@@ -167,186 +159,168 @@ namespace EasyRepository.EFCore.Generic
             return expression;
         }
 
-        public virtual void HardDelete<TEntity>(TEntity entity) where TEntity : class, new()
+        public void HardDelete<TEntity>(TEntity entity) where TEntity : class, new()
         {
-            context.Set<TEntity>().Remove(entity);
-            context.SaveChanges();
+            _context.Set<TEntity>().Remove(entity);
         }
 
-        public virtual void HardDelete<TEntity>(object id) where TEntity : class, new()
+        public void HardDelete<TEntity>(object id) where TEntity : class, new()
         {
-            var entity = context.Set<TEntity>().Find(id);
-            context.Set<TEntity>().Remove(entity);
-            context.SaveChanges();
+            var entity = _context.Set<TEntity>().Find(id);
+            _context.Set<TEntity>().Remove(entity);
         }
 
-        public virtual void HardDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public void HardDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
-            context.Set<TEntity>().Remove(entity);
-            context.SaveChanges();
+            _context.Set<TEntity>().Remove(entity);
         }
 
-        public virtual void HardDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public void HardDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
-            var entity = context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
-            context.Set<TEntity>().Remove(entity);
-            context.SaveChanges();
+            var entity = _context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
+            _context.Set<TEntity>().Remove(entity);
         }
 
-        public virtual async Task HardDeleteAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public Task HardDeleteAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            context.Set<TEntity>().Remove(entity);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _context.Set<TEntity>().Remove(entity);
+            return Task.CompletedTask;
         }
 
-        public virtual async Task HardDeleteAsync<TEntity>(object id, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task HardDeleteAsync<TEntity>(object id, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            var entity = await context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
-            context.Set<TEntity>().Remove(entity);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            var entity = await _context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
+            _context.Set<TEntity>().Remove(entity);
         }
 
-        public virtual async Task HardDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public Task HardDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
-            context.Set<TEntity>().Remove(entity);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _context.Set<TEntity>().Remove(entity);
+            return Task.CompletedTask;
         }
 
-        public virtual async Task HardDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public async Task HardDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
-            var entity = await context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
-            context.Set<TEntity>().Remove(entity);
-            await context.SaveChangesAsync(cancellationToken);
+            var entity = await _context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
+            _context.Set<TEntity>().Remove(entity);
         }
 
-        public virtual TEntity Replace<TEntity>(TEntity entity) where TEntity : class, new()
+        public TEntity Replace<TEntity>(TEntity entity) where TEntity : class, new()
         {
-            context.Entry(entity).State = EntityState.Modified;
-            context.SaveChanges();
+            _context.Entry(entity).State = EntityState.Modified;
             return entity;
         }
 
-        public virtual TEntity Replace<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public TEntity Replace<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.ModificationDate = DateTime.UtcNow;
-            context.Entry(entity).State = EntityState.Modified;
-            context.SaveChanges();
+            _context.Entry(entity).State = EntityState.Modified;
             return entity;
         }
 
-        public virtual async Task<TEntity> ReplaceAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public Task<TEntity> ReplaceAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            context.Entry(entity).State = EntityState.Modified;
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            return entity;
+            _context.Entry(entity).State = EntityState.Modified;
+            return Task.FromResult(entity);
         }
 
-        public virtual async Task<TEntity> ReplaceAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public Task<TEntity> ReplaceAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.ModificationDate = DateTime.UtcNow;
-            context.Entry(entity).State = EntityState.Modified;
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            return entity;
+            _context.Entry(entity).State = EntityState.Modified;
+            return Task.FromResult(entity);
         }
 
-        public virtual void SoftDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public void SoftDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.IsDeleted = true;
             entity.DeletionDate = DateTime.UtcNow;
             Replace<TEntity, TPrimaryKey>(entity);
         }
 
-        public virtual void SoftDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public void SoftDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
-            var entity = context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
+            var entity = _context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
             entity.IsDeleted = true;
             entity.DeletionDate = DateTime.UtcNow;
             Replace<TEntity, TPrimaryKey>(entity);
         }
 
-        public virtual async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.IsDeleted = true;
             entity.DeletionDate = DateTime.UtcNow;
             await ReplaceAsync<TEntity, TPrimaryKey>(entity, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
-            var entity = await context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false); ;
+            var entity = await _context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false); ;
             entity.IsDeleted = true;
             entity.DeletionDate = DateTime.UtcNow;
             await ReplaceAsync<TEntity, TPrimaryKey>(entity, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TEntity Update<TEntity>(TEntity entity) where TEntity : class, new()
+        public TEntity Update<TEntity>(TEntity entity) where TEntity : class, new()
         {
-            context.Set<TEntity>().Update(entity);
-            context.SaveChanges();
+            _context.Set<TEntity>().Update(entity);
             return entity;
         }
 
-        public virtual TEntity Update<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public TEntity Update<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.ModificationDate = DateTime.UtcNow;
-            context.Set<TEntity>().Update(entity);
-            context.SaveChanges();
+            _context.Set<TEntity>().Update(entity);
             return entity;
         }
 
-        public virtual async Task<TEntity> UpdateAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public Task<TEntity> UpdateAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            context.Set<TEntity>().Update(entity);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            return entity;
+            _context.Set<TEntity>().Update(entity);
+            return Task.FromResult(entity);
         }
 
-        public virtual async Task<TEntity> UpdateAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public Task<TEntity> UpdateAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entity.ModificationDate = DateTime.UtcNow;
-            context.Set<TEntity>().Update(entity);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            return entity;
+            _context.Set<TEntity>().Update(entity);
+            return Task.FromResult(entity);
         }
 
-        public virtual IEnumerable<TEntity> UpdateRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class, new()
+        public IEnumerable<TEntity> UpdateRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class, new()
         {
-            context.Set<TEntity>().UpdateRange(entities);
-            context.SaveChanges();
+            _context.Set<TEntity>().UpdateRange(entities);
             return entities;
         }
 
-        public virtual IEnumerable<TEntity> UpdateRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public IEnumerable<TEntity> UpdateRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entities.ToList().ForEach(a => a.ModificationDate = DateTime.UtcNow);
-            context.Set<TEntity>().UpdateRange(entities);
-            context.SaveChanges();
+            _context.Set<TEntity>().UpdateRange(entities);
             return entities;
         }
 
-        public virtual async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
-            context.Set<TEntity>().UpdateRange(entities);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _context.Set<TEntity>().UpdateRange(entities);
             return entities;
         }
 
-        public virtual async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
+        public async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
         {
             entities.ToList().ForEach(a => a.ModificationDate = DateTime.UtcNow);
-            context.Set<TEntity>().UpdateRange(entities);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _context.Set<TEntity>().UpdateRange(entities);
             return entities;
         }
 
-        public virtual IQueryable<TEntity> GetQueryable<TEntity>() where TEntity : class, new()
+        public IQueryable<TEntity> GetQueryable<TEntity>() where TEntity : class, new()
         {
-            return context.Set<TEntity>().AsQueryable();
+            return _context.Set<TEntity>().AsQueryable();
         }
 
-        public virtual IQueryable<TEntity> GetQueryable<TEntity>(Expression<Func<TEntity, bool>> filter) where TEntity : class, new()
+        public IQueryable<TEntity> GetQueryable<TEntity>(Expression<Func<TEntity, bool>> filter) where TEntity : class, new()
         {
-            return context.Set<TEntity>().Where(filter);
+            return _context.Set<TEntity>().Where(filter);
         }
 
         private IQueryable<TEntity> FindQueryable<TEntity>(bool asNoTracking) where TEntity : class, new()
@@ -359,103 +333,103 @@ namespace EasyRepository.EFCore.Generic
             return queryable;
         }
 
-        public virtual List<TEntity> GetMultiple<TEntity>(bool asNoTracking) where TEntity : class, new()
+        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking) where TEntity : class, new()
         {
             return FindQueryable<TEntity>(asNoTracking).ToList();
         }
 
-        public virtual async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             return await FindQueryable<TEntity>(asNoTracking).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
+        public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
         {
             return FindQueryable<TEntity>(asNoTracking).Select(projectExpression).ToList();
         }
 
-        public virtual async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             return await FindQueryable<TEntity>(asNoTracking).Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class, new()
+        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class, new()
         {
             return FindQueryable<TEntity>(asNoTracking).Where(whereExpression).ToList();
         }
 
-        public virtual async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             return await FindQueryable<TEntity>(asNoTracking).Where(whereExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
+        public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
         {
             return FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).ToList();
         }
 
-        public virtual async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             return await FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
+        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking);
             queryable = includeExpression(queryable);
             return queryable.ToList();
         }
 
-        public virtual async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking);
             queryable = includeExpression(queryable);
             return await queryable.ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
+        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return queryable.ToList();
         }
 
-        public virtual async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return await queryable.ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
+        public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return queryable.Select(projectExpression).ToList();
         }
 
-        public virtual async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return await queryable.Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
+        public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
             return FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).ToList();
         }
 
-        public virtual async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
             return await FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -464,7 +438,7 @@ namespace EasyRepository.EFCore.Generic
             return queryable.ToList();
         }
 
-        public virtual async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -473,21 +447,21 @@ namespace EasyRepository.EFCore.Generic
             return await queryable.ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
             return FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).Select(projectExpression).ToList();
         }
 
-        public virtual async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
             return await FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -496,7 +470,7 @@ namespace EasyRepository.EFCore.Generic
             return queryable.Select(projectExpression).ToList();
         }
 
-        public virtual async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -505,57 +479,57 @@ namespace EasyRepository.EFCore.Generic
             return await queryable.Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class, new()
+        public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             return queryable.FirstOrDefault();
         }
 
-        public virtual async Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
+        public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return queryable.FirstOrDefault();
         }
 
-        public async virtual Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
+        public TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
         {
             return FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).FirstOrDefault();
         }
 
-        public virtual async Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             return await FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
+        public TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return queryable.Select(projectExpression).FirstOrDefault();
         }
 
-        public virtual async Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
             queryable = includeExpression(queryable);
             return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
+        public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -563,7 +537,7 @@ namespace EasyRepository.EFCore.Generic
             return queryable.FirstOrDefault();
         }
 
-        public virtual async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -571,7 +545,7 @@ namespace EasyRepository.EFCore.Generic
             return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -580,7 +554,7 @@ namespace EasyRepository.EFCore.Generic
             return queryable.FirstOrDefault();
         }
 
-        public virtual async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -589,7 +563,7 @@ namespace EasyRepository.EFCore.Generic
             return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        public TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -597,7 +571,7 @@ namespace EasyRepository.EFCore.Generic
             return queryable.Select(projectExpression).FirstOrDefault();
         }
 
-        public virtual async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -605,7 +579,7 @@ namespace EasyRepository.EFCore.Generic
             return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        public TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -614,7 +588,7 @@ namespace EasyRepository.EFCore.Generic
             return queryable.Select(projectExpression).FirstOrDefault();
         }
 
-        public virtual async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             where TFilter : FilterBase
         {
@@ -623,50 +597,50 @@ namespace EasyRepository.EFCore.Generic
             return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TEntity GetById<TEntity>(bool asNoTracking, object id) where TEntity : class, new()
+        public TEntity GetById<TEntity>(bool asNoTracking, object id) where TEntity : class, new()
         {
-            return context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
+            return _context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
         }
 
-        public virtual async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             return await FindQueryable<TEntity>(asNoTracking).FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
+        public TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
             queryable = includeExpression(queryable);
             return queryable.FirstOrDefault();
         }
 
-        public virtual async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
             queryable = includeExpression(queryable);
             return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
+        public TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
             return queryable.Select(projectExpression).FirstOrDefault();
         }
 
-        public virtual async Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
             return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
+        public TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
             queryable = includeExpression(queryable);
             return queryable.Select(projectExpression).FirstOrDefault();
         }
 
-        public virtual async Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
+        public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class, new()
         {
             var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
             queryable = includeExpression(queryable);

--- a/src/EasyRepository.EFCore.Generic/Repository.cs
+++ b/src/EasyRepository.EFCore.Generic/Repository.cs
@@ -132,12 +132,12 @@ namespace EasyRepository.EFCore.Generic
             return count;
         }
 
-        public void SaveChanges()
+        public void Complete()
         {
             _context.SaveChanges();
         }
 
-        public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        public async Task CompleteAsync(CancellationToken cancellationToken = default)
         {
             await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/src/EasyRepository.EFCore.Generic/Startup.cs
+++ b/src/EasyRepository.EFCore.Generic/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using EasyRepository.EFCore.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace EasyRepository.EFCore.Generic
 {
@@ -30,8 +31,17 @@ namespace EasyRepository.EFCore.Generic
                 typeof(IRepository),
                 serviceProvider =>
                 {
-                    TDbContext dbContext = ActivatorUtilities.CreateInstance<TDbContext>(serviceProvider);
+                    var dbContext = ActivatorUtilities.CreateInstance<TDbContext>(serviceProvider);
                     return new Repository(dbContext);
+                },
+                serviceLifetime));
+            
+            services.Add(new ServiceDescriptor(
+                typeof(IUnitOfWork),
+                serviceProvider =>
+                {
+                    var repository = serviceProvider.GetService<IRepository>();
+                    return new UnitOfWork(repository);
                 },
                 serviceLifetime));
             return services;

--- a/src/EasyRepository.EFCore.Generic/UnitOfWork.cs
+++ b/src/EasyRepository.EFCore.Generic/UnitOfWork.cs
@@ -1,0 +1,15 @@
+﻿using EasyRepository.EFCore.Abstractions;
+
+namespace EasyRepository.EFCore.Generic;
+
+/// <summary>
+/// Implementation of Unit of work pattern
+/// </summary>
+public class UnitOfWork : IUnitOfWork
+{
+    public UnitOfWork(IRepository repository)
+    {
+        Repository = repository;
+    }
+    public IRepository Repository { get; }
+}


### PR DESCRIPTION
## Summary

This PR contains implementation of unit of work pattern

## What?

The Unit of Work pattern aims to execute all transactions to be made with the database through a single channel and to keep it in memory in one place.

## Why?

- Decouple Business code from data Access. As a result, the persistence Framework can be changed without a great effort
- Separation of Concerns
- Minimize duplicate query logic
- Testability

## How?

```csharp
var entity = await _unitOfWork.Repository.AddAsync<Author, Guid>(new Author
{
    Name = dto.Name,
    Surname = dto.Surname
});

 var book = await _unitOfWork.Repository.AddAsync<Book, Guid>(new Book
 {
     Title = "Book 123",
     TotalPage = 124,
     AuthorId = entity.Id
 });
 
await _unitOfWork.Repository.CompleteAsync();
```
