### PR TITLE
Upgraded to net6.0

### DIFF
--- a/common.props
+++ b/common.props
@@ -4,7 +4,7 @@
 		<RepositoryType>Git</RepositoryType>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<TargetFrameworks>net6.0</TargetFrameworks>
-		<Version>1.5.0</Version>
+		<Version>2.0.0</Version>
 		<LangVersion>latest</LangVersion>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<RepositoryUrl>https://github.com/furkandeveloper/EasyRepository.EFCore</RepositoryUrl>

--- a/common.props
+++ b/common.props
@@ -4,7 +4,7 @@
 		<RepositoryType>Git</RepositoryType>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<TargetFrameworks>net6.0</TargetFrameworks>
-		<Version>1.4.1</Version>
+		<Version>1.5.0</Version>
 		<LangVersion>latest</LangVersion>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<RepositoryUrl>https://github.com/furkandeveloper/EasyRepository.EFCore</RepositoryUrl>

--- a/common.props
+++ b/common.props
@@ -3,8 +3,8 @@
 		<Title>Generic Repository Pattern For Entity Framework Core</Title>
 		<RepositoryType>Git</RepositoryType>
 		<NeutralLanguage>en-US</NeutralLanguage>
-		<TargetFrameworks>net5.0</TargetFrameworks>
-		<Version>1.4.0</Version>
+		<TargetFrameworks>net6.0</TargetFrameworks>
+		<Version>1.4.1</Version>
 		<LangVersion>latest</LangVersion>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<RepositoryUrl>https://github.com/furkandeveloper/EasyRepository.EFCore</RepositoryUrl>

--- a/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
+++ b/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFilterer.Swagger" Version="2.8.0" />
+		<PackageReference Include="AutoFilterer.Swagger" Version="2.12.2" />
 		<PackageReference Include="AspNetCore.MarkdownDocumenting" Version="2.3.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.12">
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
+++ b/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
@@ -7,8 +7,8 @@
 		<PackageIconUrl />
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="AutoFilterer" Version="2.8.0" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.11" />
+	  <PackageReference Include="AutoFilterer" Version="2.12.2" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Include="folders.png">


### PR DESCRIPTION
## Summary

* Updated all packages to most recent versions
* Updated target framework from `net5.0` --> `net6.0`

## What?

Update of all packages and updated target framework

## Why?

* When using with EfCore6, I received an error (EFCore 6 support (Method not found exception)
* https://github.com/borisdj/EFCore.BulkExtensions/issues/485 
* Upon further research, it seems that EfCore5 and EfCore6 are not compatible with this method.  Such as, EfCore6 cannot consume this method from EfCore5.
* This library was not able to be used by net6.0 projects, now it is

Please let me know if any issues, I tested it on my local net6.0 project without any issues.  Deeper testing should be done, however, I believe it is stable due to no code changes were made, and only the framework version was updated.

## How?

Updated the `common.props` file (target frameworks, I removed net5 and replaced with net 6) and all nuget packages


## Questions to Repository Author

This was a very simple upgrade, is there any reason why this was not done earlier?  I feel like it was 'to-easy' and I am overlooking something that perhaps you are aware of.  

Thanks