### PR TITLE
File scoped and explicit enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,27 @@
 ***
 
 ## Give a Star 🌟
+
 If you liked the project or if **EasyRepository.EFCore** helped you, please give a star.
 
 ***
 
 ### Purpose
+
 **Easy Repository For EF Core** provides implementation generic repository pattern on Entity Framework Core
 
 ***
 
 ## What is Generic Repository Pattern
 
-The generic repository pattern implements in a separate class library project. ... The repository pattern is intended to create an Abstraction layer between the Data Access layer and Business Logic layer of an Application. It is a data access pattern that prompts a more loosely coupled approach to data access.
+The generic repository pattern implements in a separate class library project. ... The repository pattern is intended to
+create an Abstraction layer between the Data Access layer and Business Logic layer of an Application. It is a data
+access pattern that prompts a more loosely coupled approach to data access.
 
 ***
 
 ### Documentation
+
 Visit [Wiki](https://github.com/furkandeveloper/EasyRepository.EFCore/wiki) page for documentation.
 
 ## Star History

--- a/common.props
+++ b/common.props
@@ -1,21 +1,21 @@
 ﻿<Project>
-	<PropertyGroup>
-		<Title>Generic Repository Pattern For Entity Framework Core</Title>
-		<RepositoryType>Git</RepositoryType>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<TargetFrameworks>net6.0</TargetFrameworks>
-		<Version>2.0.0</Version>
-		<LangVersion>latest</LangVersion>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryUrl>https://github.com/furkandeveloper/EasyRepository.EFCore</RepositoryUrl>
-		<Authors>furkandeveloper</Authors>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<Description></Description>
-		<PackageTags>dotnet, efcore, repository-pattern, generic-repository, generic-repository-pattern</PackageTags>
-		<PackageReleaseNotes>
-			
-		</PackageReleaseNotes>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
+    <PropertyGroup>
+        <Title>Generic Repository Pattern For Entity Framework Core</Title>
+        <RepositoryType>Git</RepositoryType>
+        <NeutralLanguage>en-US</NeutralLanguage>
+        <TargetFrameworks>net6.0</TargetFrameworks>
+        <Version>2.0.0</Version>
+        <LangVersion>latest</LangVersion>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <RepositoryUrl>https://github.com/furkandeveloper/EasyRepository.EFCore</RepositoryUrl>
+        <Authors>furkandeveloper</Authors>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <Description></Description>
+        <PackageTags>dotnet, efcore, repository-pattern, generic-repository, generic-repository-pattern</PackageTags>
+        <PackageReleaseNotes>
+
+        </PackageReleaseNotes>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
 </Project>

--- a/sample/EasyRepository.Sample/Context/SampleDbContext.cs
+++ b/sample/EasyRepository.Sample/Context/SampleDbContext.cs
@@ -19,7 +19,8 @@ public class SampleDbContext : DbContext
     ///     of this class and it is not designed to be directly constructed in your application
     ///     code.
     /// </param>
-    public SampleDbContext(DbContextOptions options) : base(options)
+    public SampleDbContext(DbContextOptions options)
+        : base(options)
     {
     }
 

--- a/sample/EasyRepository.Sample/Context/SampleDbContext.cs
+++ b/sample/EasyRepository.Sample/Context/SampleDbContext.cs
@@ -1,62 +1,58 @@
-﻿using EasyRepository.Sample.Entities;
-using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿namespace EasyRepository.Sample.Context;
 
-namespace EasyRepository.Sample.Context
+using Entities;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Sample Database Context
+/// </summary>
+public class SampleDbContext : DbContext
 {
     /// <summary>
-    /// Sample Database Context
+    ///     Ctor
     /// </summary>
-    public class SampleDbContext : DbContext
+    /// <param name="options">
+    ///     The options to be used by a Microsoft.EntityFrameworkCore.DbContext. You normally
+    ///     override
+    ///     Microsoft.EntityFrameworkCore.DbContext.OnConfiguring(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder)
+    ///     or use a Microsoft.EntityFrameworkCore.DbContextOptionsBuilder to create instances
+    ///     of this class and it is not designed to be directly constructed in your application
+    ///     code.
+    /// </param>
+    public SampleDbContext(DbContextOptions options) : base(options)
     {
-        /// <summary>
-        /// Ctor
-        /// </summary>
-        /// <param name="options">
-        /// The options to be used by a Microsoft.EntityFrameworkCore.DbContext. You normally
-        ///     override Microsoft.EntityFrameworkCore.DbContext.OnConfiguring(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder)
-        ///     or use a Microsoft.EntityFrameworkCore.DbContextOptionsBuilder to create instances
-        ///     of this class and it is not designed to be directly constructed in your application
-        ///     code.
-        /// </param>
-        public SampleDbContext(DbContextOptions options) : base(options)
-        {
-        }
+    }
 
-        protected SampleDbContext()
-        {
-        }
+    protected SampleDbContext()
+    {
+    }
 
-        public virtual DbSet<Author> Authors { get; set;}
+    public virtual DbSet<Author> Authors { get; set; }
 
-        public virtual DbSet<Book> Books { get; set; }
+    public virtual DbSet<Book> Books { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-            modelBuilder.Entity<Author>(entity =>
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<Author>(
+            entity =>
             {
-                entity
-                    .HasMany(m => m.Books)
+                entity.HasMany(m => m.Books)
                     .WithOne(o => o.Author)
                     .HasForeignKey(fk => fk.AuthorId);
             });
 
-            modelBuilder.Entity<Book>(entity =>
+        modelBuilder.Entity<Book>(
+            entity =>
             {
-                entity
-                    .HasOne(o => o.Author)
+                entity.HasOne(o => o.Author)
                     .WithMany(m => m.Books)
                     .HasForeignKey(fk => fk.AuthorId);
             });
-        }
+    }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            base.OnConfiguring(optionsBuilder);
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        base.OnConfiguring(optionsBuilder);
     }
 }

--- a/sample/EasyRepository.Sample/Controllers/AuthorController.cs
+++ b/sample/EasyRepository.Sample/Controllers/AuthorController.cs
@@ -1,144 +1,167 @@
-﻿using EasyRepository.EFCore.Abstractions;
-using EasyRepository.Sample.Dtos.Request;
-using EasyRepository.Sample.Entities;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
+﻿namespace EasyRepository.Sample.Controllers;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using EasyRepository.EFCore.Ardalis.Specification;
-using EasyRepository.EFCore.Generic;
-using EasyRepository.Sample.Specs;
+using Dtos.Request;
+using EFCore.Abstractions;
+using EFCore.Ardalis.Specification;
+using EFCore.Generic;
+using Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Specs;
 
-namespace EasyRepository.Sample.Controllers
+[ApiController]
+[Route("[controller]")]
+public class AuthorController : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class AuthorController : ControllerBase
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AuthorController(IRepository repository, IUnitOfWork unitOfWork)
     {
-        private readonly IUnitOfWork _unitOfWork;
+        this._unitOfWork = unitOfWork;
+    }
 
-        public AuthorController(IRepository repository, IUnitOfWork unitOfWork)
-        {
-            _unitOfWork = unitOfWork;
-        }
-
-        [HttpGet(Name = "FilterAuthor")]
-        public async Task<IActionResult> FilterAuthorAsync([FromQuery]string name)
-        {
-            var queryable = _unitOfWork.Repository.GetQueryable<Author>();
-            //var spec = new AuthorByNameSpec(name);
-            var spec = new AuthorOrderByNameSpec(name);
-            var data = SpecificationConverter.Convert(queryable, spec);
-            return Ok(data.ToList());
-        }
-        
-        [HttpPost]
-        public async Task<IActionResult> AddAuthorAsync([FromBody] AuthorRequestDto dto)
-        {
-            var entity = await _unitOfWork.Repository.AddAsync<Author, Guid>(new Author
+    [HttpPost]
+    public async Task<IActionResult> AddAuthorAsync([FromBody] AuthorRequestDto dto)
+    {
+        var entity = await this._unitOfWork.Repository.AddAsync<Author, Guid>(
+            new Author
             {
                 Name = dto.Name,
                 Surname = dto.Surname
             });
 
-             var book = await _unitOfWork.Repository.AddAsync<Book, Guid>(new Book
-             {
-                 Title = "Book 123",
-                 TotalPage = 124,
-                 AuthorId = entity.Id
-             });
-             
-            await _unitOfWork.Repository.CompleteAsync();
-            return Ok(entity);
-        }
-
-        [HttpPost("range")]
-        public async Task<IActionResult> AddAuthorAsync([FromBody] List<AuthorRequestDto> dto)
-        {
-            var entity = await _unitOfWork.Repository.AddRangeAsync<Author, Guid>(dto.Select(s => new Author
+        var book = await this._unitOfWork.Repository.AddAsync<Book, Guid>(
+            new Book
             {
-                Name = s.Name,
-                Surname = s.Surname
-            }).ToList(), default);
+                Title = "Book 123",
+                TotalPage = 124,
+                AuthorId = entity.Id
+            });
 
-            return Ok(entity);
-        }
+        await this._unitOfWork.Repository.CompleteAsync();
 
-        [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateAuthorAsync([FromRoute] Guid id, [FromBody] AuthorRequestDto dto)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Author>(true, id);
-            entity.Name = dto.Name;
-            entity.Surname = dto.Surname;
-            var result = await _unitOfWork.Repository.UpdateAsync<Author, Guid>(entity);
-            return Ok(result);
-        }
+        return this.Ok(entity);
+    }
 
-        [HttpDelete("{id}/hard")]
-        public async Task<IActionResult> HardDeleteAsync([FromRoute] Guid id)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Author>(true, id);
-            await _unitOfWork.Repository.HardDeleteAsync<Author>(entity);
-            return NoContent();
-        }
+    [HttpPost("range")]
+    public async Task<IActionResult> AddAuthorAsync([FromBody] List<AuthorRequestDto> dto)
+    {
+        var entity = await this._unitOfWork.Repository.AddRangeAsync<Author, Guid>(
+            dto.Select(
+                    s => new Author
+                    {
+                        Name = s.Name,
+                        Surname = s.Surname
+                    })
+                .ToList());
 
-        [HttpDelete("{id}/soft")]
-        public async Task<IActionResult> SoftDeleteAsync([FromRoute] Guid id)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Author>(true, id);
-            await _unitOfWork.Repository.SoftDeleteAsync<Author, Guid>(entity);
-            return NoContent();
-        }
+        return this.Ok(entity);
+    }
 
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetByIdAsync([FromRoute] Guid id)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Author>(true, id);
-            return Ok(entity);
-        }
+    [HttpGet(Name = "FilterAuthor")]
+    public async Task<IActionResult> FilterAuthorAsync([FromQuery] string name)
+    {
+        var queryable = this._unitOfWork.Repository.GetQueryable<Author>();
+        //var spec = new AuthorByNameSpec(name);
+        var spec = new AuthorOrderByNameSpec(name);
+        var data = SpecificationConverter.Convert(queryable, spec);
 
-        [HttpGet("multiple")]
-        public async Task<IActionResult> GetMultipleAsync()
-        {
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Author>(false);
-            return Ok(entities);
-        }
+        return this.Ok(data.ToList());
+    }
 
-        [HttpGet("selectable-multiple")]
-        public async Task<IActionResult> GetSelectableMultipleAsync()
-        {
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Author, object>(false, select => new
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetByIdAsync([FromRoute] Guid id)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Author>(true, id);
+
+        return this.Ok(entity);
+    }
+
+    [HttpGet("filterable-multiple")]
+    public async Task<IActionResult> GetFilterableMultipleAsync([FromQuery] AuthorFilterDto dto)
+    {
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Author, AuthorFilterDto, object>(
+            false,
+            dto,
+            select => new
             {
                 SelectName = select.Name,
                 SelectDate = select.CreationDate
             });
-            return Ok(entities);
-        }
 
-        [HttpGet("filterable-multiple")]
-        public async Task<IActionResult> GetFilterableMultipleAsync([FromQuery] AuthorFilterDto dto)
-        {
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Author, AuthorFilterDto, object>(false, dto, select => new
+        return this.Ok(entities);
+    }
+
+    [HttpGet("includable-filterable-selectable-multiple")]
+    public async Task<IActionResult> GetIncludeableFilterableMultipleAsync([FromQuery] AuthorFilterDto dto)
+    {
+        Func<IQueryable<Author>, IIncludableQueryable<Author, object>> include = a => a.Include(i => i.Books);
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Author, AuthorFilterDto, object>(
+            false,
+            dto,
+            select => new
+            {
+                SelectName = select.Name,
+                SelectDate = select.CreationDate
+            },
+            include);
+
+        return this.Ok(entities);
+    }
+
+    [HttpGet("multiple")]
+    public async Task<IActionResult> GetMultipleAsync()
+    {
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Author>(false);
+
+        return this.Ok(entities);
+    }
+
+    [HttpGet("selectable-multiple")]
+    public async Task<IActionResult> GetSelectableMultipleAsync()
+    {
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Author, object>(
+            false,
+            select => new
             {
                 SelectName = select.Name,
                 SelectDate = select.CreationDate
             });
-            return Ok(entities);
-        }
 
-        [HttpGet("includable-filterable-selectable-multiple")]
-        public async Task<IActionResult> GetIncludeableFilterableMultipleAsync([FromQuery] AuthorFilterDto dto)
-        {
-            Func<IQueryable<Author>, IIncludableQueryable<Author, object>> include = a => a.Include(i => i.Books);
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Author, AuthorFilterDto, object>(false, dto, select => new
-            {
-                SelectName = select.Name,
-                SelectDate = select.CreationDate
-            }, include);
-            return Ok(entities);
-        }
+        return this.Ok(entities);
+    }
+
+    [HttpDelete("{id}/hard")]
+    public async Task<IActionResult> HardDeleteAsync([FromRoute] Guid id)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Author>(true, id);
+        await this._unitOfWork.Repository.HardDeleteAsync(entity);
+
+        return this.NoContent();
+    }
+
+    [HttpDelete("{id}/soft")]
+    public async Task<IActionResult> SoftDeleteAsync([FromRoute] Guid id)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Author>(true, id);
+        await this._unitOfWork.Repository.SoftDeleteAsync<Author, Guid>(entity);
+
+        return this.NoContent();
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateAuthorAsync([FromRoute] Guid id, [FromBody] AuthorRequestDto dto)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Author>(true, id);
+        entity.Name = dto.Name;
+        entity.Surname = dto.Surname;
+        var result = await this._unitOfWork.Repository.UpdateAsync<Author, Guid>(entity);
+
+        return this.Ok(result);
     }
 }

--- a/sample/EasyRepository.Sample/Controllers/BookController.cs
+++ b/sample/EasyRepository.Sample/Controllers/BookController.cs
@@ -1,134 +1,154 @@
-﻿using EasyRepository.EFCore.Abstractions;
-using EasyRepository.Sample.Dtos.Request;
-using EasyRepository.Sample.Entities;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
+﻿namespace EasyRepository.Sample.Controllers;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using EasyRepository.EFCore.Generic;
+using Dtos.Request;
+using EFCore.Generic;
+using Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 
-namespace EasyRepository.Sample.Controllers
+[ApiController]
+[Route("[controller]")]
+public class BookController : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class BookController : ControllerBase
+    private readonly IUnitOfWork _unitOfWork;
+
+    public BookController(IUnitOfWork unitOfWork)
     {
-        private readonly IUnitOfWork _unitOfWork;
+        this._unitOfWork = unitOfWork;
+    }
 
-        public BookController(IUnitOfWork unitOfWork)
-        {
-            _unitOfWork = unitOfWork;
-        }
-
-        [HttpPost("authors/{authorId}")]
-        public async Task<IActionResult> AddBookAsync([FromRoute] Guid authorId,[FromBody] BookRequestDto dto)
-        {
-            var entity = await _unitOfWork.Repository.AddAsync<Book, Guid>(new Book
+    [HttpPost("authors/{authorId}")]
+    public async Task<IActionResult> AddBookAsync([FromRoute] Guid authorId, [FromBody] BookRequestDto dto)
+    {
+        var entity = await this._unitOfWork.Repository.AddAsync<Book, Guid>(
+            new Book
             {
                 Title = dto.Title,
                 TotalPage = dto.TotalPage,
                 AuthorId = authorId
-            }, default);
+            });
 
-            await _unitOfWork.Repository.CompleteAsync();
+        await this._unitOfWork.Repository.CompleteAsync();
 
-            return Ok(entity);
-        }
+        return this.Ok(entity);
+    }
 
-        [HttpPost("authors/{authorId}/range")]
-        public async Task<IActionResult> AddBookAsync([FromRoute] Guid authorId, [FromBody] List<BookRequestDto> dto)
-        {
-            var entity = await _unitOfWork.Repository.AddRangeAsync<Book, Guid>(dto.Select(s => new Book
-            {
-                Title = s.Title,
-                TotalPage = s.TotalPage,
-                AuthorId = authorId
-            }).ToList(), default);
+    [HttpPost("authors/{authorId}/range")]
+    public async Task<IActionResult> AddBookAsync([FromRoute] Guid authorId, [FromBody] List<BookRequestDto> dto)
+    {
+        var entity = await this._unitOfWork.Repository.AddRangeAsync<Book, Guid>(
+            dto.Select(
+                    s => new Book
+                    {
+                        Title = s.Title,
+                        TotalPage = s.TotalPage,
+                        AuthorId = authorId
+                    })
+                .ToList());
 
-            await _unitOfWork.Repository.CompleteAsync();
-            return Ok(entity);
-        }
+        await this._unitOfWork.Repository.CompleteAsync();
 
-        [HttpPut("{id}/authors/{authorId}")]
-        public async Task<IActionResult> UpdateAuthorAsync([FromRoute] Guid id,[FromRoute] Guid authorId, [FromBody] BookRequestDto dto)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Book>(true, id);
-            entity.Title = dto.Title;
-            entity.TotalPage = dto.TotalPage;
-            entity.AuthorId = authorId;
-            var result = await _unitOfWork.Repository.UpdateAsync<Book, Guid>(entity);
-            await _unitOfWork.Repository.CompleteAsync();
-            return Ok(result);
-        }
+        return this.Ok(entity);
+    }
 
-        [HttpDelete("{id}/hard")]
-        public async Task<IActionResult> HardDeleteAsync([FromRoute] Guid id)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Book>(true, id);
-            await _unitOfWork.Repository.HardDeleteAsync<Book>(entity);
-            await _unitOfWork.Repository.CompleteAsync();
-            return NoContent();
-        }
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetByIdAsync([FromRoute] Guid id)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Book>(true, id);
 
-        [HttpDelete("{id}/soft")]
-        public async Task<IActionResult> SoftDeleteAsync([FromRoute] Guid id)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Book>(true, id);
-            await _unitOfWork.Repository.SoftDeleteAsync<Book, Guid>(entity);
-            await _unitOfWork.Repository.CompleteAsync();
-            return NoContent();
-        }
+        return this.Ok(entity);
+    }
 
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetByIdAsync([FromRoute] Guid id)
-        {
-            var entity = await _unitOfWork.Repository.GetByIdAsync<Book>(true, id);
-            return Ok(entity);
-        }
-
-        [HttpGet("multiple")]
-        public async Task<IActionResult> GetMultipleAsync()
-        {
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Book>(false);
-            return Ok(entities);
-        }
-
-        [HttpGet("selectable-multiple")]
-        public async Task<IActionResult> GetSelectableMultipleAsync()
-        {
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Book, object>(false, select => new
+    [HttpGet("filterable-multiple")]
+    public async Task<IActionResult> GetFilterableMultipleAsync([FromQuery] BookFilterDto dto)
+    {
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Book, BookFilterDto, object>(
+            false,
+            dto,
+            select => new
             {
                 SelectTitle = select.Title,
                 SelectTotalPage = select.TotalPage
             });
-            return Ok(entities);
-        }
 
-        [HttpGet("filterable-multiple")]
-        public async Task<IActionResult> GetFilterableMultipleAsync([FromQuery] BookFilterDto dto)
-        {
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Book, BookFilterDto, object>(false, dto, select => new
-            {
-                SelectTitle = select.Title,
-                SelectTotalPage = select.TotalPage
-            });
-            return Ok(entities);
-        }
+        return this.Ok(entities);
+    }
 
-        [HttpGet("includable-filterable-selectable-multiple")]
-        public async Task<IActionResult> GetIncludeableFilterableMultipleAsync([FromQuery] BookFilterDto dto)
-        {
-            Func<IQueryable<Book>, IIncludableQueryable<Book, object>> include = a => a.Include(i => i.Author);
-            var entities = await _unitOfWork.Repository.GetMultipleAsync<Book, BookFilterDto, object>(false, dto, select => new
+    [HttpGet("includable-filterable-selectable-multiple")]
+    public async Task<IActionResult> GetIncludeableFilterableMultipleAsync([FromQuery] BookFilterDto dto)
+    {
+        Func<IQueryable<Book>, IIncludableQueryable<Book, object>> include = a => a.Include(i => i.Author);
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Book, BookFilterDto, object>(
+            false,
+            dto,
+            select => new
             {
                 SelectName = select.Title,
                 SelectDate = select.CreationDate,
                 Author = select.Author.Name
-            }, include);
-            return Ok(entities);
-        }
+            },
+            include);
+
+        return this.Ok(entities);
+    }
+
+    [HttpGet("multiple")]
+    public async Task<IActionResult> GetMultipleAsync()
+    {
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Book>(false);
+
+        return this.Ok(entities);
+    }
+
+    [HttpGet("selectable-multiple")]
+    public async Task<IActionResult> GetSelectableMultipleAsync()
+    {
+        var entities = await this._unitOfWork.Repository.GetMultipleAsync<Book, object>(
+            false,
+            select => new
+            {
+                SelectTitle = select.Title,
+                SelectTotalPage = select.TotalPage
+            });
+
+        return this.Ok(entities);
+    }
+
+    [HttpDelete("{id}/hard")]
+    public async Task<IActionResult> HardDeleteAsync([FromRoute] Guid id)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Book>(true, id);
+        await this._unitOfWork.Repository.HardDeleteAsync(entity);
+        await this._unitOfWork.Repository.CompleteAsync();
+
+        return this.NoContent();
+    }
+
+    [HttpDelete("{id}/soft")]
+    public async Task<IActionResult> SoftDeleteAsync([FromRoute] Guid id)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Book>(true, id);
+        await this._unitOfWork.Repository.SoftDeleteAsync<Book, Guid>(entity);
+        await this._unitOfWork.Repository.CompleteAsync();
+
+        return this.NoContent();
+    }
+
+    [HttpPut("{id}/authors/{authorId}")]
+    public async Task<IActionResult> UpdateAuthorAsync([FromRoute] Guid id, [FromRoute] Guid authorId, [FromBody] BookRequestDto dto)
+    {
+        var entity = await this._unitOfWork.Repository.GetByIdAsync<Book>(true, id);
+        entity.Title = dto.Title;
+        entity.TotalPage = dto.TotalPage;
+        entity.AuthorId = authorId;
+        var result = await this._unitOfWork.Repository.UpdateAsync<Book, Guid>(entity);
+        await this._unitOfWork.Repository.CompleteAsync();
+
+        return this.Ok(result);
     }
 }

--- a/sample/EasyRepository.Sample/Dtos/Request/AuthorFilterDto.cs
+++ b/sample/EasyRepository.Sample/Dtos/Request/AuthorFilterDto.cs
@@ -1,30 +1,27 @@
-﻿using AutoFilterer.Attributes;
-using AutoFilterer.Types;
+﻿namespace EasyRepository.Sample.Dtos.Request;
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using AutoFilterer.Attributes;
+using AutoFilterer.Enums;
+using AutoFilterer.Types;
 
-namespace EasyRepository.Sample.Dtos.Request
+[PossibleSortings("Name", "Surname", "CreationDate", "ModificationDate", "DeletionDate")]
+public class AuthorFilterDto : PaginationFilterBase
 {
-    [PossibleSortings("Name", "Surname","CreationDate", "ModificationDate", "DeletionDate")]
-    public class AuthorFilterDto : PaginationFilterBase
+    public AuthorFilterDto()
     {
-        public AuthorFilterDto()
-        {
-            this.Sort = "Name";
-            this.SortBy = AutoFilterer.Enums.Sorting.Descending;
-        }
-
-        [ToLowerContainsComparison]
-        public string Name { get; set; }
-
-        [ToLowerContainsComparison]
-        public string Surname { get; set; }
-
-        public Range<DateTime> CreationDate { get; set; }
-
-        public Range<DateTime> ModificationDate { get; set; }
-        public Range<DateTime> DeletionDate { get; set; }
+        this.Sort = "Name";
+        this.SortBy = Sorting.Descending;
     }
+
+    [ToLowerContainsComparison]
+    public string Name { get; set; }
+
+    [ToLowerContainsComparison]
+    public string Surname { get; set; }
+
+    public Range<DateTime> CreationDate { get; set; }
+
+    public Range<DateTime> ModificationDate { get; set; }
+    public Range<DateTime> DeletionDate { get; set; }
 }

--- a/sample/EasyRepository.Sample/Dtos/Request/AuthorRequestDto.cs
+++ b/sample/EasyRepository.Sample/Dtos/Request/AuthorRequestDto.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿namespace EasyRepository.Sample.Dtos.Request;
 
-namespace EasyRepository.Sample.Dtos.Request
+public class AuthorRequestDto
 {
-    public class AuthorRequestDto
-    {
-        public string Name { get; set; }
+    public string Name { get; set; }
 
-        public string Surname { get; set; }
-    }
+    public string Surname { get; set; }
 }

--- a/sample/EasyRepository.Sample/Dtos/Request/BookFilterDto.cs
+++ b/sample/EasyRepository.Sample/Dtos/Request/BookFilterDto.cs
@@ -1,29 +1,26 @@
-﻿using AutoFilterer.Attributes;
-using AutoFilterer.Types;
+﻿namespace EasyRepository.Sample.Dtos.Request;
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using AutoFilterer.Attributes;
+using AutoFilterer.Enums;
+using AutoFilterer.Types;
 
-namespace EasyRepository.Sample.Dtos.Request
+[PossibleSortings("Title", "CreationDate", "ModificationDate", "DeletionDate")]
+public class BookFilterDto : PaginationFilterBase
 {
-    [PossibleSortings("Title", "CreationDate", "ModificationDate", "DeletionDate")]
-    public class BookFilterDto : PaginationFilterBase
+    public BookFilterDto()
     {
-        public BookFilterDto()
-        {
-            this.Sort = "Title";
-            this.SortBy = AutoFilterer.Enums.Sorting.Descending;
-        }
-
-        [ToLowerContainsComparison]
-        public string Title { get; set; }
-
-        public Range<int> TotalPage { get; set; }
-
-        public Range<DateTime> CreationDate { get; set; }
-
-        public Range<DateTime> ModificationDate { get; set; }
-        public Range<DateTime> DeletionDate { get; set; }
+        this.Sort = "Title";
+        this.SortBy = Sorting.Descending;
     }
+
+    [ToLowerContainsComparison]
+    public string Title { get; set; }
+
+    public Range<int> TotalPage { get; set; }
+
+    public Range<DateTime> CreationDate { get; set; }
+
+    public Range<DateTime> ModificationDate { get; set; }
+    public Range<DateTime> DeletionDate { get; set; }
 }

--- a/sample/EasyRepository.Sample/Dtos/Request/BookRequestDto.cs
+++ b/sample/EasyRepository.Sample/Dtos/Request/BookRequestDto.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿namespace EasyRepository.Sample.Dtos.Request;
 
-namespace EasyRepository.Sample.Dtos.Request
+public class BookRequestDto
 {
-    public class BookRequestDto
-    {
-        public string Title { get; set; }
+    public string Title { get; set; }
 
-        public int TotalPage { get; set; }
-    }
+    public int TotalPage { get; set; }
 }

--- a/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
+++ b/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="AutoFilterer.Swagger" Version="2.12.2" />
-		<PackageReference Include="AspNetCore.MarkdownDocumenting" Version="2.3.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
-	</ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="AutoFilterer.Swagger" Version="2.12.2"/>
+        <PackageReference Include="AspNetCore.MarkdownDocumenting" Version="2.3.1"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7"/>
+    </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\EasyRepository.EFCore.Ardalis.Specification\EasyRepository.EFCore.Ardalis.Specification.csproj" />
-		<ProjectReference Include="..\..\src\EasyRepository.EFCore.Generic\EasyRepository.EFCore.Generic.csproj" />
-	</ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\EasyRepository.EFCore.Ardalis.Specification\EasyRepository.EFCore.Ardalis.Specification.csproj"/>
+        <ProjectReference Include="..\..\src\EasyRepository.EFCore.Generic\EasyRepository.EFCore.Generic.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/sample/EasyRepository.Sample/Entities/Author.cs
+++ b/sample/EasyRepository.Sample/Entities/Author.cs
@@ -1,19 +1,16 @@
-﻿using EasyRepository.EFCore.Abstractions;
+﻿namespace EasyRepository.Sample.Entities;
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+using EFCore.Abstractions;
 
-namespace EasyRepository.Sample.Entities
+public class Author : EasyBaseEntity<Guid>
 {
-    public class Author : EasyBaseEntity<Guid>
-    {
-        public string Name { get; set; }
+    public string Name { get; set; }
 
-        public string Surname { get; set; }
+    public string Surname { get; set; }
 
-        [JsonIgnore]
-        public virtual ICollection<Book> Books { get; set; }
-    }
+    [JsonIgnore]
+    public virtual ICollection<Book> Books { get; set; }
 }

--- a/sample/EasyRepository.Sample/Entities/Book.cs
+++ b/sample/EasyRepository.Sample/Entities/Book.cs
@@ -1,19 +1,14 @@
-﻿using EasyRepository.EFCore.Abstractions;
+﻿namespace EasyRepository.Sample.Entities;
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using EFCore.Abstractions;
 
-namespace EasyRepository.Sample.Entities
+public class Book : EasyBaseEntity<Guid>
 {
-    public class Book : EasyBaseEntity<Guid>
-    {
-        public string Title { get; set; }
+    public Guid AuthorId { get; set; }
+    public string Title { get; set; }
 
-        public Guid AuthorId { get; set; }
+    public int TotalPage { get; set; }
 
-        public int TotalPage { get; set; }
-
-        public virtual Author Author { get; set; }
-    }
+    public virtual Author Author { get; set; }
 }

--- a/sample/EasyRepository.Sample/Program.cs
+++ b/sample/EasyRepository.Sample/Program.cs
@@ -1,26 +1,20 @@
+namespace EasyRepository.Sample;
+
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
-namespace EasyRepository.Sample
+public class Program
 {
-    public class Program
+    public static IHostBuilder CreateHostBuilder(string[] args)
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+        return Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+    }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
+    public static void Main(string[] args)
+    {
+        CreateHostBuilder(args)
+            .Build()
+            .Run();
     }
 }

--- a/sample/EasyRepository.Sample/Specs/AuthorByNameSpec.cs
+++ b/sample/EasyRepository.Sample/Specs/AuthorByNameSpec.cs
@@ -1,17 +1,16 @@
-﻿using Ardalis.Specification;
-using EasyRepository.Sample.Entities;
+﻿namespace EasyRepository.Sample.Specs;
 
-namespace EasyRepository.Sample.Specs
+using Ardalis.Specification;
+using Entities;
+
+/// <summary>
+///     Author By Name specification
+/// </summary>
+public sealed class AuthorByNameSpec : Specification<Author>
 {
-    /// <summary>
-    /// Author By Name specification
-    /// </summary>
-    public sealed class AuthorByNameSpec : Specification<Author>
+    /// <inheritdoc />
+    public AuthorByNameSpec(string name)
     {
-        /// <inheritdoc />
-        public AuthorByNameSpec(string name)
-        {
-            Query.Where(c => c.Name == name);
-        }
+        this.Query.Where(c => c.Name == name);
     }
 }

--- a/sample/EasyRepository.Sample/Specs/AuthorOrderByNameSpec.cs
+++ b/sample/EasyRepository.Sample/Specs/AuthorOrderByNameSpec.cs
@@ -1,36 +1,35 @@
-﻿using Ardalis.Specification;
-using EasyRepository.Sample.Entities;
+﻿namespace EasyRepository.Sample.Specs;
 
-namespace EasyRepository.Sample.Specs
+using Ardalis.Specification;
+using Entities;
+
+/// <summary>
+///     Order by author name specification
+/// </summary>
+public sealed class AuthorOrderByNameSpec : Specification<Author>
 {
-    /// <summary>
-    /// Order by author name specification
-    /// </summary>
-    public sealed class AuthorOrderByNameSpec : Specification<Author>
+    /// <inheritdoc />
+    public AuthorOrderByNameSpec(string name)
     {
-        /// <inheritdoc />
-        public AuthorOrderByNameSpec(string name)
-        {
-            Query.ApplyBaseRules().ApplyByName(name).OrderBy(o => o.Name);
-        }
+        this.Query.ApplyBaseRules()
+            .ApplyByName(name)
+            .OrderBy(o => o.Name);
+    }
+}
+
+public static class AuthorSpecification
+{
+    public static ISpecificationBuilder<Author> ApplyBaseRules(this ISpecificationBuilder<Author> specificationBuilder)
+    {
+        specificationBuilder.Include(x => x.Books);
+
+        return specificationBuilder;
     }
 
-    public static class AuthorSpecification
+    public static ISpecificationBuilder<Author> ApplyByName(this ISpecificationBuilder<Author> specificationBuilder, string name)
     {
-        public static ISpecificationBuilder<Author> ApplyBaseRules(
-            this ISpecificationBuilder<Author> specificationBuilder)
-        {
-            specificationBuilder.Include(x => x.Books);
+        specificationBuilder.Where(a => a.Name.Contains(name));
 
-            return specificationBuilder;
-        }
-        
-        public static ISpecificationBuilder<Author> ApplyByName(
-            this ISpecificationBuilder<Author> specificationBuilder, string name)
-        {
-            specificationBuilder.Where(a => a.Name.Contains(name));
-
-            return specificationBuilder;
-        }
+        return specificationBuilder;
     }
 }

--- a/sample/EasyRepository.Sample/Startup.cs
+++ b/sample/EasyRepository.Sample/Startup.cs
@@ -1,6 +1,11 @@
+namespace EasyRepository.Sample;
+
+using System;
+using System.IO;
+using System.Reflection;
 using AutoFilterer.Swagger;
-using EasyRepository.EFCore.Generic;
-using EasyRepository.Sample.Context;
+using Context;
+using EFCore.Generic;
 using MarkdownDocumenting.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -8,84 +13,80 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System;
-using System.IO;
-using System.Reflection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerUI;
 
-namespace EasyRepository.Sample
+public class Startup
 {
-    public class Startup
+    public Startup(IConfiguration configuration)
     {
-        public IConfiguration Configuration { get; }
+        this.Configuration = configuration;
+    }
 
-        public Startup(IConfiguration configuration)
+    public IConfiguration Configuration { get; }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
         {
-            Configuration = configuration;
-        }
-        // This method gets called by the runtime. Use this method to add services to the container.
-        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services.AddControllersWithViews();
-
-            services.AddDbContext<SampleDbContext>(options =>
-            {
-                options.UseNpgsql(Configuration.GetConnectionString("DefaultConnection"));
-            }, ServiceLifetime.Transient);
-            
-            services.ApplyEasyRepository<SampleDbContext>();
-
-            services.AddSwaggerGen(options =>
-            {
-                options.SwaggerDoc("EasyRepository", new Microsoft.OpenApi.Models.OpenApiInfo()
-                {
-                    Title = "Easy Repository",
-                    Version = "1.0.0",
-                    Description = "This repo, provides implement generic repository pattern on ef core",
-                    Contact = new Microsoft.OpenApi.Models.OpenApiContact()
-                    {
-                        Email = "furkan.dvlp@gmail.com",
-                        Url = new Uri("https://github.com/furkandeveloper/EasyRepository.EFCore")
-                    }
-                });
-                options.UseAutoFiltererParameters();
-                var docFile = $"{Assembly.GetEntryAssembly().GetName().Name}.xml";
-                var filePath = Path.Combine(AppContext.BaseDirectory, docFile);
-
-                if (File.Exists((filePath)))
-                {
-                    options.IncludeXmlComments(filePath);
-                }
-                options.DescribeAllParametersInCamelCase();
-            });
-            services.AddDocumentation();
+            app.UseDeveloperExceptionPage();
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
+        app.UseRouting();
+        app.UseSwagger();
 
-            app.UseRouting();
-            app.UseSwagger();
-
-            app.UseSwaggerUI(options =>
+        app.UseSwaggerUI(
+            options =>
             {
                 options.EnableDeepLinking();
                 options.ShowExtensions();
                 options.DisplayRequestDuration();
-                options.DocExpansion(Swashbuckle.AspNetCore.SwaggerUI.DocExpansion.None);
+                options.DocExpansion(DocExpansion.None);
                 options.RoutePrefix = "api-docs";
                 options.SwaggerEndpoint("/swagger/EasyRepository/swagger.json", "EasyProfilerSwagger");
             });
-            app.UseDocumentation(opts => this.Configuration.Bind("DocumentationOptions", opts));
-            app.UseEndpoints(endpoints =>
+        app.UseDocumentation(opts => this.Configuration.Bind("DocumentationOptions", opts));
+        app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+    }
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllersWithViews();
+
+        services.AddDbContext<SampleDbContext>(options => { options.UseNpgsql(this.Configuration.GetConnectionString("DefaultConnection")); }, ServiceLifetime.Transient);
+
+        services.ApplyEasyRepository<SampleDbContext>();
+
+        services.AddSwaggerGen(
+            options =>
             {
-                endpoints.MapControllers();
+                options.SwaggerDoc(
+                    "EasyRepository",
+                    new OpenApiInfo
+                    {
+                        Title = "Easy Repository",
+                        Version = "1.0.0",
+                        Description = "This repo, provides implement generic repository pattern on ef core",
+                        Contact = new OpenApiContact
+                        {
+                            Email = "furkan.dvlp@gmail.com",
+                            Url = new Uri("https://github.com/furkandeveloper/EasyRepository.EFCore")
+                        }
+                    });
+                options.UseAutoFiltererParameters();
+                var docFile = $"{Assembly.GetEntryAssembly().GetName().Name}.xml";
+                var filePath = Path.Combine(AppContext.BaseDirectory, docFile);
+
+                if (File.Exists(filePath))
+                {
+                    options.IncludeXmlComments(filePath);
+                }
+
+                options.DescribeAllParametersInCamelCase();
             });
-        }
+        services.AddDocumentation();
     }
 }

--- a/src/EasyRepository.EFCore.Abstractions/EasyBaseEntity.cs
+++ b/src/EasyRepository.EFCore.Abstractions/EasyBaseEntity.cs
@@ -21,11 +21,6 @@ public abstract class EasyBaseEntity<TPrimaryKey> : IEasyEntity<TPrimaryKey>, IE
     public virtual TPrimaryKey Id { get; set; }
 
     /// <summary>
-    ///     Modification Date <see cref="{DateTime}" />
-    /// </summary>
-    public virtual DateTime? ModificationDate { get; set; }
-
-    /// <summary>
     ///     Deletion Date <see cref="{DateTime}" />
     /// </summary>
     public virtual DateTime? DeletionDate { get; set; }
@@ -34,4 +29,9 @@ public abstract class EasyBaseEntity<TPrimaryKey> : IEasyEntity<TPrimaryKey>, IE
     ///     Is Deleted <see cref="{Boolean}" />
     /// </summary>
     public virtual bool IsDeleted { get; set; }
+
+    /// <summary>
+    ///     Modification Date <see cref="{DateTime}" />
+    /// </summary>
+    public virtual DateTime? ModificationDate { get; set; }
 }

--- a/src/EasyRepository.EFCore.Abstractions/EasyBaseEntity.cs
+++ b/src/EasyRepository.EFCore.Abstractions/EasyBaseEntity.cs
@@ -1,38 +1,37 @@
-﻿using System;
+﻿namespace EasyRepository.EFCore.Abstractions;
 
-namespace EasyRepository.EFCore.Abstractions
+using System;
+
+/// <summary>
+///     This abstraction implemented base properties for entities
+/// </summary>
+/// <typeparam name="TPrimaryKey">
+///     Primary Key type of the entity
+/// </typeparam>
+public abstract class EasyBaseEntity<TPrimaryKey> : IEasyEntity<TPrimaryKey>, IEasyCreateDateEntity, IEasyUpdateDateEntity, IEasySoftDeleteEntity
 {
     /// <summary>
-    /// This abstraction implemented base properties for entities
+    ///     Creation Date <see cref="{DateTime}" />
     /// </summary>
-    /// <typeparam name="TPrimaryKey">
-    /// Primary Key type of the entity
-    /// </typeparam>
-    public abstract class EasyBaseEntity<TPrimaryKey> : IEasyEntity<TPrimaryKey>, IEasyCreateDateEntity, IEasyUpdateDateEntity, IEasySoftDeleteEntity
-    {
-        /// <summary>
-        /// Creation Date <see cref="{DateTime}"/>
-        /// </summary>
-        public virtual DateTime CreationDate { get; set; }
+    public virtual DateTime CreationDate { get; set; }
 
-        /// <summary>
-        /// Primary Key <see cref="{TPrimaryKey}"/>
-        /// </summary>
-        public virtual TPrimaryKey Id { get; set; }
+    /// <summary>
+    ///     Primary Key <see cref="{TPrimaryKey}" />
+    /// </summary>
+    public virtual TPrimaryKey Id { get; set; }
 
-        /// <summary>
-        /// Modification Date <see cref="{DateTime}"/>
-        /// </summary>
-        public virtual DateTime? ModificationDate { get; set; }
+    /// <summary>
+    ///     Modification Date <see cref="{DateTime}" />
+    /// </summary>
+    public virtual DateTime? ModificationDate { get; set; }
 
-        /// <summary>
-        /// Deletion Date <see cref="{DateTime}"/>
-        /// </summary>
-        public virtual DateTime? DeletionDate { get; set; }
+    /// <summary>
+    ///     Deletion Date <see cref="{DateTime}" />
+    /// </summary>
+    public virtual DateTime? DeletionDate { get; set; }
 
-        /// <summary>
-        /// Is Deleted <see cref="{Boolean}"/>
-        /// </summary>
-        public virtual bool IsDeleted { get; set; }
-    }
+    /// <summary>
+    ///     Is Deleted <see cref="{Boolean}" />
+    /// </summary>
+    public virtual bool IsDeleted { get; set; }
 }

--- a/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
+++ b/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
     <PropertyGroup>
         <PackageIcon>folders.png</PackageIcon>
-        <PackageIconUrl />
+        <PackageIconUrl/>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AutoFilterer" Version="2.12.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
+        <PackageReference Include="AutoFilterer" Version="2.12.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9"/>
     </ItemGroup>
     <ItemGroup>
         <None Include="folders.png">

--- a/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
+++ b/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\common.props"/>
+    <Import Project="..\..\common.props" />
 
     <PropertyGroup>
         <PackageIcon>folders.png</PackageIcon>
-        <PackageIconUrl/>
+        <PackageIconUrl />
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AutoFilterer" Version="2.12.2"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9"/>
+        <PackageReference Include="AutoFilterer" Version="2.12.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
     </ItemGroup>
     <ItemGroup>
         <None Include="folders.png">

--- a/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
+++ b/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-	<PropertyGroup>
-		<PackageIcon>folders.png</PackageIcon>
-		<PackageIconUrl />
-	</PropertyGroup>
-	<ItemGroup>
-	  <PackageReference Include="AutoFilterer" Version="2.12.2" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
-	</ItemGroup>
-	<ItemGroup>
-	  <None Include="folders.png">
-	    <Pack>True</Pack>
-	    <PackagePath></PackagePath>
-	  </None>
-	</ItemGroup>
+    <PropertyGroup>
+        <PackageIcon>folders.png</PackageIcon>
+        <PackageIconUrl/>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="AutoFilterer" Version="2.12.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="folders.png">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/src/EasyRepository.EFCore.Abstractions/Enums/EfTrackingOptions.cs
+++ b/src/EasyRepository.EFCore.Abstractions/Enums/EfTrackingOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace EasyRepository.EFCore.Abstractions.Enums;
+
+public enum EfTrackingOptions
+{
+        
+    /// <summary>
+    /// Disables EfCore change tracking
+    /// </summary>
+    AsNoTracking,
+            
+    /// <summary>
+    /// Enables EfCore Change Tracking
+    /// </summary>
+    WithTracking
+}

--- a/src/EasyRepository.EFCore.Abstractions/Enums/EfTrackingOptions.cs
+++ b/src/EasyRepository.EFCore.Abstractions/Enums/EfTrackingOptions.cs
@@ -2,14 +2,13 @@
 
 public enum EfTrackingOptions
 {
-        
     /// <summary>
-    /// Disables EfCore change tracking
+    ///     Disables EfCore change tracking
     /// </summary>
     AsNoTracking,
-            
+
     /// <summary>
-    /// Enables EfCore Change Tracking
+    ///     Enables EfCore Change Tracking
     /// </summary>
     WithTracking
 }

--- a/src/EasyRepository.EFCore.Abstractions/IEasyCreateDateEntity.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IEasyCreateDateEntity.cs
@@ -1,15 +1,14 @@
-﻿using System;
+﻿namespace EasyRepository.EFCore.Abstractions;
 
-namespace EasyRepository.EFCore.Abstractions
+using System;
+
+/// <summary>
+///     This interface implemented creation date for entity
+/// </summary>
+public interface IEasyCreateDateEntity
 {
     /// <summary>
-    /// This interface implemented creation date for entity
+    ///     Creation Date
     /// </summary>
-    public interface IEasyCreateDateEntity
-    {
-        /// <summary>
-        /// Creation Date
-        /// </summary>
-        public DateTime CreationDate { get; set; }
-    }
+    public DateTime CreationDate { get; set; }
 }

--- a/src/EasyRepository.EFCore.Abstractions/IEasyEntity.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IEasyEntity.cs
@@ -1,16 +1,15 @@
-﻿namespace EasyRepository.EFCore.Abstractions
+﻿namespace EasyRepository.EFCore.Abstractions;
+
+/// <summary>
+///     This interface implemented primary key entity
+/// </summary>
+/// <typeparam name="TPrimaryKey">
+///     Primary Key type of the entity
+/// </typeparam>
+internal interface IEasyEntity<TPrimaryKey>
 {
     /// <summary>
-    /// This interface implemented primary key entity
+    ///     Primary Key
     /// </summary>
-    /// <typeparam name="TPrimaryKey">
-    /// Primary Key type of the entity
-    /// </typeparam>
-    internal interface IEasyEntity<TPrimaryKey>
-    {
-        /// <summary>
-        /// Primary Key
-        /// </summary>
-        TPrimaryKey Id { get; set; }
-    }
+    TPrimaryKey Id { get; set; }
 }

--- a/src/EasyRepository.EFCore.Abstractions/IEasySoftDeleteEntity.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IEasySoftDeleteEntity.cs
@@ -1,20 +1,19 @@
-﻿using System;
+﻿namespace EasyRepository.EFCore.Abstractions;
 
-namespace EasyRepository.EFCore.Abstractions
+using System;
+
+/// <summary>
+///     This interface implemented Deletion Date and Is Deleted property for entity
+/// </summary>
+public interface IEasySoftDeleteEntity
 {
     /// <summary>
-    /// This interface implemented Deletion Date and Is Deleted property for entity
+    ///     Deletion Date
     /// </summary>
-    public interface IEasySoftDeleteEntity
-    {
-        /// <summary>
-        /// Deletion Date
-        /// </summary>
-        public DateTime? DeletionDate { get; set; }
+    public DateTime? DeletionDate { get; set; }
 
-        /// <summary>
-        /// Is Deleted
-        /// </summary>
-        public bool IsDeleted { get; set; }
-    }
+    /// <summary>
+    ///     Is Deleted
+    /// </summary>
+    public bool IsDeleted { get; set; }
 }

--- a/src/EasyRepository.EFCore.Abstractions/IEasyUpdateDateEntity.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IEasyUpdateDateEntity.cs
@@ -1,15 +1,14 @@
-﻿using System;
+﻿namespace EasyRepository.EFCore.Abstractions;
 
-namespace EasyRepository.EFCore.Abstractions
+using System;
+
+/// <summary>
+///     This interface implemented Modification Date property for entity
+/// </summary>
+public interface IEasyUpdateDateEntity
 {
     /// <summary>
-    /// This interface implemented Modification Date property for entity
+    ///     Modification Date
     /// </summary>
-    public interface IEasyUpdateDateEntity
-    {
-        /// <summary>
-        /// Modification Date
-        /// </summary>
-        public DateTime? ModificationDate { get; set; }
-    }
+    public DateTime? ModificationDate { get; set; }
 }

--- a/src/EasyRepository.EFCore.Abstractions/IRepository.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IRepository.cs
@@ -332,8 +332,8 @@ public interface IRepository
     /// </returns>
     TEntity GetById<TEntity>(bool asNoTracking, object id)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking and <see cref="object" /> id. This method provides get entity by
     ///     id. In additional returns <see cref="{TEntity}" />
@@ -356,7 +356,8 @@ public interface IRepository
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity by id
-    ///     with includable entities. In additional this method returns <see>
+    ///     with includable entities. In additional this method returns
+    ///     <see>
     ///         <cref>{TEntity}</cref>
     ///     </see>
     /// </summary>
@@ -373,14 +374,15 @@ public interface IRepository
     ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
     /// </param>
     /// <returns>
-    ///     Returns <see>
+    ///     Returns
+    ///     <see>
     ///         <cref>{TEntity}</cref>
     ///     </see>
     /// </returns>
     TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity by id
@@ -430,8 +432,8 @@ public interface IRepository
     /// </returns>
     TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
     ///     project expression. This method performs get projected object by id with includable entities. In additional this
@@ -490,8 +492,8 @@ public interface IRepository
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
@@ -543,8 +545,8 @@ public interface IRepository
     /// </returns>
     Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id. This method provides get entity by id
     ///     async version. In additional returns <see cref="{TEntity}" />
@@ -591,8 +593,8 @@ public interface IRepository
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="CancellationToken" />
@@ -649,8 +651,8 @@ public interface IRepository
         bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
     ///     project expression. This method performs get projected object by id with includable entities async version. In
@@ -712,7 +714,7 @@ public interface IRepository
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
@@ -760,7 +762,7 @@ public interface IRepository
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method  returns List of Entity without filter. <see cref="List{TEntity}" />
     /// </summary>
@@ -797,7 +799,7 @@ public interface IRepository
     /// </returns>
     List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method provides without filter get all entity but you can convert it to any object you want.
     ///     In additional this method takes <see cref="Expression{Func}" /> returns <see cref="List{TProjected}" />
@@ -839,7 +841,7 @@ public interface IRepository
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="Expression{Func}" /> performs apply filter get all entity. In additional returns
     ///     <see cref="List{TEntity}" />
@@ -884,7 +886,7 @@ public interface IRepository
     /// </returns>
     List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="Expression{Func}" /> where expression and <see cref="Expression{Func}" /> select
     ///     expression. This method performs apply filter and convert returns get all entity. In additional returns
@@ -930,7 +932,7 @@ public interface IRepository
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> and <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method
     ///     performs get all with includable entities. In additional this method returns <see cref="List{TEntity}" />
@@ -972,7 +974,7 @@ public interface IRepository
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" />, <see cref="Expression{Func}" /> and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method perform get all entities with filter and
@@ -993,7 +995,8 @@ public interface IRepository
     /// <returns>
     ///     Returns <see cref="List{TEntity}" />
     /// </returns>
-    List<TEntity> GetMultiple<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+    List<TEntity> GetMultiple<TEntity>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
 
 
@@ -1028,7 +1031,7 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="Expression{Func}" />
@@ -1060,7 +1063,7 @@ public interface IRepository
         EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
-    
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object. This method
@@ -1085,7 +1088,7 @@ public interface IRepository
     List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object. This method
     ///     performs generate LINQ expressions for Entities over DTOs automatically. In additional returns
@@ -1137,7 +1140,7 @@ public interface IRepository
     List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" />  pagination filter object and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get all entities
@@ -1195,7 +1198,7 @@ public interface IRepository
     List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
     ///     <see cref="Expression{Func}" /> project expression. This method performs get all projected objects with apply
@@ -1262,7 +1265,7 @@ public interface IRepository
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
     ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
@@ -1314,7 +1317,7 @@ public interface IRepository
     /// </returns>
     Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method  returns List of Entity without filter async version. <see cref="List{TEntity}" />
     /// </summary>
@@ -1353,7 +1356,7 @@ public interface IRepository
     /// </returns>
     Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" />. This method performs
     ///     without filter get all entity but you can convert it to any object you want
@@ -1397,7 +1400,7 @@ public interface IRepository
     /// </returns>
     Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" />. This method performs apply
     ///     filter get all entity. In additional returns <see cref="List{TEntity}" />
@@ -1497,7 +1500,7 @@ public interface IRepository
     /// </returns>
     Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> and <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method
     ///     performs get all with includable entities async version. In additional this method returns
@@ -1516,7 +1519,8 @@ public interface IRepository
     /// <returns>
     ///     Returns <see cref="List{TEntity}" />
     /// </returns>
-    Task<List<TEntity>> GetMultipleAsync<TEntity>(EfTrackingOptions asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(
+        EfTrackingOptions asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
 
 
@@ -1546,7 +1550,7 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" />, <see cref="Expression{Func}" />,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="CancellationToken" />. This method perform
@@ -1607,8 +1611,8 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression, <see cref="Expression{Func}" /> select
@@ -1666,7 +1670,7 @@ public interface IRepository
     Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object and
     ///     <see cref="CancellationToken" />. This method performs generate LINQ expressions for Entities over DTOs
@@ -1722,7 +1726,7 @@ public interface IRepository
         CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="CancellationToken" /> cancellation token.
@@ -1786,7 +1790,7 @@ public interface IRepository
         CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
     ///     <see cref="Expression{Func}" /> project expression. This method performs get all projected objects with apply
@@ -1857,7 +1861,7 @@ public interface IRepository
         where TEntity : class
         where TFilter : FilterBase;
 
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
     ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
@@ -1943,7 +1947,7 @@ public interface IRepository
     /// </returns>
     TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking and <see cref="Expression{Func}" /> where expression. This
     ///     method performs get entity with apply filter. In additional returns <see cref="{TEntity}" />
@@ -1985,7 +1989,7 @@ public interface IRepository
     /// </returns>
     TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
@@ -2034,7 +2038,7 @@ public interface IRepository
     /// </returns>
     TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression and
     ///     <see cref="Expression{Func}" /> project the expression. This method performs get projected object with apply
@@ -2092,7 +2096,7 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
     ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
@@ -2148,7 +2152,7 @@ public interface IRepository
     TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking and <see cref="{TFilter}" /> filter object. This object must be
     ///     type <see cref="FilterBase" />. This method perform get entity with filter. In additional returns
@@ -2199,7 +2203,7 @@ public interface IRepository
     TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
     ///     expression and <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs get and
@@ -2240,7 +2244,6 @@ public interface IRepository
     ///     Type of Filter <see cref="FilterBase" />
     /// </typeparam>
     /// <typeparam name="TProjected">The projection to return</typeparam>
-
     /// <param name="asNoTracking">
     ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
     /// </param>
@@ -2381,7 +2384,7 @@ public interface IRepository
     /// </returns>
     Task<TEntity> GetSingleAsync<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
@@ -2407,7 +2410,7 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
@@ -2463,7 +2466,7 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
     ///     <see cref="Expression{Func}" /> project the expression and <see cref="CancellationToken" /> cancellation token.
@@ -2493,7 +2496,6 @@ public interface IRepository
         EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
-
 
 
     /// <summary>
@@ -2528,7 +2530,7 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
     ///     <see cref="Expression{Func}" /> project expression, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
@@ -2586,7 +2588,7 @@ public interface IRepository
     Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
-    
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="CancellationToken" /> cancellation token and
     ///     <see cref="{TFilter}" /> filter object. This object must be type <see cref="FilterBase" />. This method perform get
@@ -2643,8 +2645,8 @@ public interface IRepository
         CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
-    
-    
+
+
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
     ///     expression, <see cref="CancellationToken" /> cancellation token and <see cref="{TFilter}" /> filterable object

--- a/src/EasyRepository.EFCore.Abstractions/IRepository.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IRepository.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFilterer.Types;
+using Enums;
 using Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
@@ -146,14 +147,14 @@ public interface IRepository
     /// <typeparam name="TPrimaryKey">
     ///     Type of primary key
     /// </typeparam>
-    /// <param name="entites">
+    /// <param name="entities">
     ///     The entities to be added
     /// </param>
     /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>
     ///     Returns <see cref="Task{IEnumerable{TEntity}}" />
     /// </returns>
-    Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entites, CancellationToken cancellationToken = default)
+    Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
         where TEntity : EasyBaseEntity<TPrimaryKey>;
 
 
@@ -248,7 +249,7 @@ public interface IRepository
     /// <returns>
     ///     Returns <see cref="int" />
     /// </returns>
-    Task<int> Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+    Task<int> CountAsync<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
 
 
@@ -331,7 +332,55 @@ public interface IRepository
     /// </returns>
     TEntity GetById<TEntity>(bool asNoTracking, object id)
         where TEntity : class;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="object" /> id. This method provides get entity by
+    ///     id. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetById<TEntity>(EfTrackingOptions asNoTracking, object id)
+        where TEntity : class;
 
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity by id
+    ///     with includable entities. In additional this method returns <see>
+    ///         <cref>{TEntity}</cref>
+    ///     </see>
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see>
+    ///         <cref>{TEntity}</cref>
+    ///     </see>
+    /// </returns>
+    TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+    
+    
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity by id
@@ -340,8 +389,8 @@ public interface IRepository
     /// <typeparam name="TEntity">
     ///     Type of entity
     /// </typeparam>
-    /// <param name="asnoTracking">
-    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core?   <see cref="EfTrackingOptions" />
     /// </param>
     /// <param name="id">
     ///     PK of entity
@@ -352,12 +401,12 @@ public interface IRepository
     /// <returns>
     ///     Returns <see cref="{TEntity}" />
     /// </returns>
-    TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+    TEntity GetById<TEntity>(EfTrackingOptions asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
 
 
     /// <summary>
-    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
     ///     project expression. This method performs get projected object by id with includable entities. In additional this
     ///     method returns <see cref="{TProjected}" />
     /// </summary>
@@ -381,10 +430,37 @@ public interface IRepository
     /// </returns>
     TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
+    ///     project expression. This method performs get projected object by id with includable entities. In additional this
+    ///     method returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetById<TEntity, TProjected>(EfTrackingOptions asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
 
 
     /// <summary>
-    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id,
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
     ///     This method performs get projected object by id with includable entities. In additional this method returns
     ///     <see cref="{TProjected}" />
@@ -414,6 +490,39 @@ public interface IRepository
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
+    ///     This method performs get projected object by id with includable entities. In additional this method returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetById<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id. This method provides get entity by id
@@ -434,6 +543,27 @@ public interface IRepository
     /// </returns>
     Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id. This method provides get entity by id
+    ///     async version. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetByIdAsync<TEntity>(EfTrackingOptions asNoTracking, object id, CancellationToken cancellationToken = default)
+        where TEntity : class;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
@@ -445,7 +575,7 @@ public interface IRepository
     ///     Type of entity
     /// </typeparam>
     /// <param name="asNoTracking">
-    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    ///     Do you want the entity to be tracked by the EF Core?   <see cref="EfTrackingOptions" />
     /// </param>
     /// <param name="id">
     ///     PK of entity
@@ -461,9 +591,38 @@ public interface IRepository
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="CancellationToken" />
+    ///     cancellation token. This method performs get entity by id with includable entities. In additional this method
+    ///     returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetByIdAsync<TEntity>(
+        EfTrackingOptions asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
 
     /// <summary>
-    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
     ///     project expression. This method performs get projected object by id with includable entities async version. In
     ///     additional this method returns <see cref="{TProjected}" />
     /// </summary>
@@ -490,9 +649,39 @@ public interface IRepository
         bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
+    ///     project expression. This method performs get projected object by id with includable entities async version. In
+    ///     additional this method returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetByIdAsync<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
 
     /// <summary>
-    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id,
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
     ///     This method performs get projected object by id with includable entities async version. In additional this method
     ///     returns <see cref="{TProjected}" />
@@ -523,6 +712,39 @@ public interface IRepository
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
+    ///     This method performs get projected object by id with includable entities async version. In additional this method
+    ///     returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetByIdAsync<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
 
     /// <summary>
     ///     This method  returns List of Entity without filter. <see cref="List{TEntity}" />
@@ -537,6 +759,21 @@ public interface IRepository
     ///     Returns <see cref="List{TEntity}" />
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking)
+        where TEntity : class;
+    
+    /// <summary>
+    ///     This method  returns List of Entity without filter. <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(EfTrackingOptions asNoTracking)
         where TEntity : class;
 
     /// <summary>
@@ -560,6 +797,29 @@ public interface IRepository
     /// </returns>
     List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method provides without filter get all entity but you can convert it to any object you want.
+    ///     In additional this method takes <see cref="Expression{Func}" /> returns <see cref="List{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?   <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TProjected>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
 
     /// <summary>
     ///     This method takes <see cref="Expression{Func}" /> performs apply filter get all entity. In additional returns
@@ -578,6 +838,25 @@ public interface IRepository
     ///     Returns <see cref="List{TEntity}" />
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> performs apply filter get all entity. In additional returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where expression see <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
         where TEntity : class;
 
     /// <summary>
@@ -605,6 +884,33 @@ public interface IRepository
     /// </returns>
     List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> where expression and <see cref="Expression{Func}" /> select
+    ///     expression. This method performs apply filter and convert returns get all entity. In additional returns
+    ///     <see cref="List{TPrtojected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of Projected object
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where Expression
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TProjected>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> and <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method
@@ -623,6 +929,25 @@ public interface IRepository
     ///     Returns <see cref="List{TEntity}" />
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> and <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method
+    ///     performs get all with includable entities. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?   <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> expression
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(EfTrackingOptions asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
 
     /// <summary>
@@ -647,6 +972,30 @@ public interface IRepository
     /// </returns>
     List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" />, <see cref="Expression{Func}" /> and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method perform get all entities with filter and
+    ///     includable entities. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
@@ -679,6 +1028,39 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="Expression{Func}" />
+    ///     select expression. This method perform get all projected object with filter and include entities. In additional
+    ///     returns <see cref="List{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+    
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object. This method
@@ -703,6 +1085,31 @@ public interface IRepository
     List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object. This method
+    ///     performs generate LINQ expressions for Entities over DTOs automatically. In additional returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity, TFilter>(EfTrackingOptions asNoTracking, TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" />  pagination filter object and
@@ -730,6 +1137,34 @@ public interface IRepository
     List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" />  pagination filter object and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get all entities
+    ///     with apply filter and includable entities. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter Object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?   <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity, TFilter>(EfTrackingOptions asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
@@ -760,6 +1195,37 @@ public interface IRepository
     List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
+    ///     <see cref="Expression{Func}" /> project expression. This method performs get all projected objects with apply
+    ///     filter. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter Object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
@@ -796,6 +1262,42 @@ public interface IRepository
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
+    ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    ///     include expression. This method performs get all projected objects with apply filter and get all includable
+    ///     entities. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(
+        EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
 
     /// <summary>
     ///     This method  returns List of Entity without filter async version. <see cref="List{TEntity}" />
@@ -811,6 +1313,22 @@ public interface IRepository
     ///     Returns <see cref="List{TEntity}" />
     /// </returns>
     Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default)
+        where TEntity : class;
+    
+    /// <summary>
+    ///     This method  returns List of Entity without filter async version. <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(EfTrackingOptions asNoTracking, CancellationToken cancellationToken = default)
         where TEntity : class;
 
     /// <summary>
@@ -835,6 +1353,30 @@ public interface IRepository
     /// </returns>
     Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" />. This method performs
+    ///     without filter get all entity but you can convert it to any object you want
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
 
     /// <summary>
     ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" />. This method performs apply
@@ -855,6 +1397,27 @@ public interface IRepository
     /// </returns>
     Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" />. This method performs apply
+    ///     filter get all entity. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where Expression
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
 
     /// <summary>
     ///     This method takes <see cref="Expression{Func}" /> where expression and <see cref="Expression{Func}" /> select
@@ -876,11 +1439,41 @@ public interface IRepository
     /// <param name="asNoTracking">
     ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
     /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>
     ///     Returns <see cref="List{TProjected}" />
     /// </returns>
     Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> where expression and <see cref="Expression{Func}" /> select
+    ///     expression. This method performs apply filter async version and convert returns get all entity. In additional
+    ///     returns <see cref="List{TPrtojected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of Projected object
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where Expression
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
 
@@ -904,6 +1497,28 @@ public interface IRepository
     /// </returns>
     Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> and <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method
+    ///     performs get all with includable entities async version. In additional this method returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?   <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> expression
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(EfTrackingOptions asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" />, <see cref="Expression{Func}" />,
@@ -931,6 +1546,34 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" />, <see cref="Expression{Func}" />,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="CancellationToken" />. This method perform
+    ///     get all entities with filter and includable entities async version. In additional this method returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
@@ -964,6 +1607,40 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression, <see cref="Expression{Func}" /> select
+    ///     expression and <see cref="CancellationToken" /> cancellation token. This method perform get all projected object
+    ///     with filter and include entities async version. In additional returns <see cref="List{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object and
@@ -987,6 +1664,31 @@ public interface IRepository
     ///     Returns <see cref="List{TEntity}" />
     /// </returns>
     Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object and
+    ///     <see cref="CancellationToken" />. This method performs generate LINQ expressions for Entities over DTOs
+    ///     automatically async version. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(EfTrackingOptions asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
 
@@ -1020,6 +1722,37 @@ public interface IRepository
         CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="CancellationToken" /> cancellation token.
+    ///     This method performs get all entities with apply filter and get all includable entities async version. In
+    ///     additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(
+        EfTrackingOptions asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
@@ -1050,6 +1783,39 @@ public interface IRepository
     /// </returns>
     Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
+    ///     <see cref="Expression{Func}" /> project expression. This method performs get all projected objects with apply
+    ///     filter async version. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter Object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
+        EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
@@ -1087,6 +1853,44 @@ public interface IRepository
     /// </returns>
     Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
+    ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    ///     include expression. This method performs get all projected objects with apply filter and get all includable
+    ///     entities async version. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
+        EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
@@ -1139,6 +1943,25 @@ public interface IRepository
     /// </returns>
     TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="Expression{Func}" /> where expression. This
+    ///     method performs get entity with apply filter. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
@@ -1161,6 +1984,29 @@ public interface IRepository
     ///     Returns <see cref="{TEntity}" />
     /// </returns>
     TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
+    ///     apply filter and includable entities. In additional this method returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?   <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
 
     /// <summary>
@@ -1187,6 +2033,32 @@ public interface IRepository
     ///     Returns <see cref="{TProjected}" />
     /// </returns>
     TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression and
+    ///     <see cref="Expression{Func}" /> project the expression. This method performs get projected object with apply
+    ///     filter. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class;
 
     /// <summary>
@@ -1220,6 +2092,38 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    ///     include expression. This method performs get projected object with apply filter and includable entity. In
+    ///     additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking and <see cref="{TFilter}" /> filter object. This object must be
@@ -1242,6 +2146,30 @@ public interface IRepository
     ///     Returns <see cref="{TEntity}" />
     /// </returns>
     TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="{TFilter}" /> filter object. This object must be
+    ///     type <see cref="FilterBase" />. This method perform get entity with filter. In additional returns
+    ///     <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity, TFilter>(EfTrackingOptions asNoTracking, TFilter filter)
         where TEntity : class
         where TFilter : FilterBase;
 
@@ -1271,6 +2199,34 @@ public interface IRepository
     TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
+    ///     expression and <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs get and
+    ///     includable entity with filter. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?   <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity, TFilter>(EfTrackingOptions asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression and
@@ -1283,6 +2239,8 @@ public interface IRepository
     /// <typeparam name="TFilter">
     ///     Type of Filter <see cref="FilterBase" />
     /// </typeparam>
+    /// <typeparam name="TProjected">The projection to return</typeparam>
+
     /// <param name="asNoTracking">
     ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
     /// </param>
@@ -1293,6 +2251,31 @@ public interface IRepository
     ///     Returns <see cref="{TProjected}" />
     /// </returns>
     TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression and
+    ///     <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs get projected object
+    ///     with filter. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">The projection to return</typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?   <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected, TFilter>(EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
         where TFilter : FilterBase;
 
@@ -1308,6 +2291,7 @@ public interface IRepository
     /// <typeparam name="TFilter">
     ///     Type of Filter <see cref="FilterBase" />
     /// </typeparam>
+    /// <typeparam name="TProjected">The projection to return</typeparam>
     /// <param name="asNoTracking">
     ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
     /// </param>
@@ -1325,6 +2309,38 @@ public interface IRepository
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="{TFilter}" /> filterable
+    ///     object <see cref="FilterBase" />. This method performs get projected object with filter. In additional returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">The projection to return</typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected, TFilter>(
+        EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking and <see cref="Expression{Func}" /> where expression. This
@@ -1346,6 +2362,26 @@ public interface IRepository
     Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
 
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="Expression{Func}" /> where expression. This
+    ///     method performs get entity with apply filter async version. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity>(EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+    
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
@@ -1369,6 +2405,32 @@ public interface IRepository
     /// </returns>
     Task<TEntity> GetSingleAsync<TEntity>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
+    ///     apply filter and includable entities async version. In additional this method returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
 
@@ -1401,6 +2463,37 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="Expression{Func}" /> project the expression and <see cref="CancellationToken" /> cancellation token.
+    ///     This method performs get projected object with apply filter async version. In additional returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
 
 
     /// <summary>
@@ -1435,6 +2528,39 @@ public interface IRepository
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="Expression{Func}" /> project expression, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
+    ///     expression and <see cref="CancellationToken" /> cancellation token. This method performs get projected object with
+    ///     apply filter and includable entity async version. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected>(
+        EfTrackingOptions asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="CancellationToken" /> cancellation token and
@@ -1460,6 +2586,32 @@ public interface IRepository
     Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="CancellationToken" /> cancellation token and
+    ///     <see cref="{TFilter}" /> filter object. This object must be type <see cref="FilterBase" />. This method perform get
+    ///     entity with filter async version. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity, TFilter>(EfTrackingOptions asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
@@ -1491,6 +2643,38 @@ public interface IRepository
         CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
+    
+    
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
+    ///     expression, <see cref="CancellationToken" /> cancellation token and <see cref="{TFilter}" /> filterable object
+    ///     <see cref="FilterBase" />. This method performs get and includable entity with filter. In additional returns
+    ///     <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core?  <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity, TFilter>(
+        EfTrackingOptions asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
@@ -1504,6 +2688,7 @@ public interface IRepository
     /// <typeparam name="TFilter">
     ///     Type of Filter <see cref="FilterBase" />
     /// </typeparam>
+    /// <typeparam name="TProjected">The projected type to return</typeparam>
     /// <param name="asNoTracking">
     ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
     /// </param>
@@ -1522,6 +2707,36 @@ public interface IRepository
 
     /// <summary>
     ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
+    ///     <see cref="CancellationToken" /> cancellation token and <see cref="{TFilter}" /> filterable object
+    ///     <see cref="FilterBase" />. This method performs get projected object with filter. In additional returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">The projected type to return</typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
+        EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
     ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression, <see cref="CancellationToken" />
     ///     cancellation token and <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs
     ///     get projected object with filter. In additional returns <see cref="{TProjected}" />
@@ -1532,12 +2747,14 @@ public interface IRepository
     /// <typeparam name="TFilter">
     ///     Type of Filter <see cref="FilterBase" />
     /// </typeparam>
+    /// <typeparam name="TProjected">The projected type to return</typeparam>
     /// <param name="asNoTracking">
     ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
     /// </param>
     /// <param name="filter">
     ///     Filter object of type FilterBase <see cref="FilterBase" />
     /// </param>
+    /// <param name="projectExpression">The expression to create the projection object</param>
     /// <param name="includeExpression">
     ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
     /// </param>
@@ -1547,6 +2764,39 @@ public interface IRepository
     /// </returns>
     Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression, <see cref="CancellationToken" />
+    ///     cancellation token and <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs
+    ///     get projected object with filter. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">The projected type to return</typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? <see cref="EfTrackingOptions" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">The expression to create the projection object</param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
+        EfTrackingOptions asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase;
@@ -1613,6 +2863,7 @@ public interface IRepository
     /// <param name="entity">
     ///     The entity to be deleted
     /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>
     ///     Returns <see cref="Task" />
     /// </returns>
@@ -1688,7 +2939,7 @@ public interface IRepository
 
     /// <summary>
     ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs replace operation
-    ///     for EasyBaseEntity. In additional this method returs <see cref="{TEntity}" />
+    ///     for EasyBaseEntity. In additional this method returns <see cref="{TEntity}" />
     /// </summary>
     /// <typeparam name="TEntity">
     ///     Type of Entity
@@ -1725,7 +2976,7 @@ public interface IRepository
 
     /// <summary>
     ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs replace operation
-    ///     for EasyBaseEntity. In additional this method returs <see cref="Task{TEntity}" />
+    ///     for EasyBaseEntity. In additional this method returns <see cref="Task{TEntity}" />
     /// </summary>
     /// <typeparam name="TEntity">
     ///     Type of Entity
@@ -1736,6 +2987,7 @@ public interface IRepository
     /// <param name="entity">
     ///     The entity to be replaced
     /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>
     ///     Returns <see cref="Task{TEntity}" />
     /// </returns>
@@ -1755,6 +3007,7 @@ public interface IRepository
     /// <param name="id">
     ///     PK of Entity
     /// </param>
+    /// <param name="entity"></param>
     void SoftDelete<TEntity, TPrimaryKey>(TEntity entity)
         where TEntity : EasyBaseEntity<TPrimaryKey>;
 
@@ -1828,7 +3081,7 @@ public interface IRepository
 
     /// <summary>
     ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update operation
-    ///     for EasyBaseEntity. In additional this method returs <see cref="{TEntity}" />
+    ///     for EasyBaseEntity. In additional this method returns <see cref="{TEntity}" />
     /// </summary>
     /// <typeparam name="TEntity">
     ///     Type of Entity
@@ -1864,7 +3117,7 @@ public interface IRepository
 
     /// <summary>
     ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update operation
-    ///     for EasyBaseEntity. In additional this method returs <see cref="Task{TEntity}" />
+    ///     for EasyBaseEntity. In additional this method returns <see cref="Task{TEntity}" />
     /// </summary>
     /// <typeparam name="TEntity">
     ///     Type of Entity
@@ -1875,6 +3128,7 @@ public interface IRepository
     /// <param name="entity">
     ///     The entity to be updated
     /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>
     ///     Returns <see cref="Task{TEntity}" />
     /// </returns>
@@ -1896,7 +3150,7 @@ public interface IRepository
 
     /// <summary>
     ///     This method takes <see cref="IEnumerable{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update
-    ///     range operation for EasyBaseEntity. In additional this method returs <see cref="IEnumerable{TEntity}" />
+    ///     range operation for EasyBaseEntity. In additional this method returns <see cref="IEnumerable{TEntity}" />
     /// </summary>
     /// <typeparam name="TEntity">
     ///     Type of Entity
@@ -1932,7 +3186,7 @@ public interface IRepository
 
     /// <summary>
     ///     This method takes <see cref="IEnumerable{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update
-    ///     operation for EasyBaseEntity. In additional this method returs <see cref="Task{TResult}" />
+    ///     operation for EasyBaseEntity. In additional this method returns <see cref="Task{TResult}" />
     /// </summary>
     /// <typeparam name="TEntity">
     ///     Type of Entity
@@ -1941,8 +3195,9 @@ public interface IRepository
     ///     Type of Primary Key
     /// </typeparam>
     /// <param name="entities">
-    ///     The entites to be updated
+    ///     The entities to be updated
     /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>
     ///     Returns <see cref="Task{TResult}" />
     /// </returns>

--- a/src/EasyRepository.EFCore.Abstractions/IRepository.cs
+++ b/src/EasyRepository.EFCore.Abstractions/IRepository.cs
@@ -1,1672 +1,1951 @@
-﻿using AutoFilterer.Types;
-using Microsoft.EntityFrameworkCore.Query;
+﻿namespace EasyRepository.EFCore.Abstractions;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoFilterer.Types;
+using Microsoft.EntityFrameworkCore.Query;
 
-namespace EasyRepository.EFCore.Abstractions
+/// <summary>
+///     This interface implemented base database operation with generic repository pattern
+/// </summary>
+public interface IRepository
 {
     /// <summary>
-    /// This interface implemented base database operation with generic repository pattern
+    ///     This method takes <see cref="{TEntity}" /> and performs entity insert operation. In additional this methods returns
+    ///     <see cref="{TEntity}" />
     /// </summary>
-    public interface IRepository
-    {
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and performs entity insert operation. In additional this methods returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity <see cref="{TEntity}"/>
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be added
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity Add<TEntity>(TEntity entity) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and performs entity insert async. In additional this methods returns <see cref="Task{TEntity}"/> 
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity <see cref="{TEntity}"/>
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be added
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task{TEntity}"/>
-        /// </returns>
-        Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="EasyBaseEntity{TPrimaryKey}"/> and performs entity insert operation. In additional this methods returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of entity primary key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be added
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity Add<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="EasyBaseEntity{TPrimaryKey}"/> and performs entity insert operation async version. In additional this methods returns <see cref="Task{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of entity primary key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be added
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns></returns>
-        Task<TEntity> AddAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This methods takes <see cref="IEnumerable{TEntity}"/> and performs entity insert range operation. In additional this methods returns <see cref="IEnumerable{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="entities">
-        /// The entity to be added
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="IEnumerable{TEntity}"/>
-        /// </returns>
-        IEnumerable<TEntity> AddRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="IEnumerable{TEntity}"/> and performs entity insert range operation async version. In additional this methods returns <see cref="IEnumerable{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="entities">
-        /// The entities to be added
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task{IEnumerable{TEntity}}"/>
-        /// </returns>
-        Task<IEnumerable<TEntity>> AddRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="IEnumerable{EasyBaseEntity{TPrimaryKey}}"/> and performs entity insert range operation. In additional this methods returns <see cref="IEnumerable{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entities">
-        /// The entities to be added
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="IEnumerable{TEntity}"/>
-        /// </returns>
-        IEnumerable<TEntity> AddRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="IEnumerable{EasyBaseEntity{TPrimaryKey}}"/> and performs entity insert range operation. In additional this methods returns <see cref="Task{IEnumerable{TEntity}}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of primary key
-        /// </typeparam>
-        /// <param name="entites">
-        /// The entities to be added
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task{IEnumerable{TEntity}}"/>
-        /// </returns>
-        Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entites, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and performs entity hard delete operation.
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be deleted
-        /// </param>
-        void HardDelete<TEntity>(TEntity entity) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and <see cref="CancellationToken"/>. This method performs entity hard delete operation. In additional this methods returns <see cref="Task"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be deleted
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task HardDeleteAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Object"/> and performs entity hard delete operation
-        /// </summary>
-        /// <param name="id">
-        /// PK of Entity
-        /// </param>
-        void HardDelete<TEntity>(object id) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Object"/> an <see cref="CancellationToken"/>. This method performs hard delete operation async version. In additional returns <see cref="Task"/>
-        /// </summary>
-        /// <param name="id">
-        /// Pk of Entity
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task HardDeleteAsync<TEntity>(object id, CancellationToken cancellationToken = default) where TEntity : class;
-
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and performs hard delete operation
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key for Entity
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be deleted
-        /// </param>
-        void HardDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and performs hard delete operation async version for EasyBaseEntity. In additional this method returns <see cref="Task"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be deleted
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task HardDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TPrimaryKey}"/> and performs hard delete operation by id.
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="id">
-        /// PK of Entity
-        /// </param>
-        void HardDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TPrimaryKey}"/> and <see cref="CancellationToken"/>. This method performs hard delete operation by id async version. In additional this method returns <see cref="Task"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="id">
-        /// PK of Entity
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task HardDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-
-        /// <summary>
-        /// This method takes <see cref="{TPrimaryKey}"/> and performs soft delete operation
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="id">
-        /// PK of Entity
-        /// </param>
-        void SoftDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> performs soft delete operation. In additional this method returns <see cref="Task"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be deleted
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task SoftDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TPrimaryKey}"/> and performs soft delete operation by id.
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="id">
-        /// PK of Entity
-        /// </param>
-        void SoftDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TPrimaryKey}"/> and <see cref="CancellationToken"/>. This method performs soft delete operation by id async version. In additional this method returns <see cref="Task"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="id">
-        /// PK of Entity
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task SoftDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> performs update operation. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be updated
-        /// </param>
-        TEntity Update<TEntity>(TEntity entity) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and <see cref="CancellationToken"/> performs update operation async version. In additional this methods returns <see cref="Task{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be updated
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task<TEntity> UpdateAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="IEnumerable{TEntity}"/> performs update operation. In additional returns <see cref="IEnumerable{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="entities">
-        /// The entities to be updated
-        /// </param>
-        IEnumerable<TEntity> UpdateRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="IEnumerable{TEntity}"/> and <see cref="CancellationToken"/> performs update operation async version. In additional this methods returns <see cref="Task{TResult}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="entities">
-        /// The entities to be updated
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task{TResult}"/>
-        /// </returns>
-        Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and <see cref="{TPrimaryKey}"/>. This method performs update operation for EasyBaseEntity. In additional this method returs <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be updated
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity Update<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and <see cref="{TPrimaryKey}"/>. This method performs update operation for EasyBaseEntity. In additional this method returs <see cref="Task{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be updated
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="Task{TEntity}"/>
-        /// </returns>
-        Task<TEntity> UpdateAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="IEnumerable{TEntity}"/> and <see cref="{TPrimaryKey}"/>. This method performs update range operation for EasyBaseEntity. In additional this method returs <see cref="IEnumerable{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entities">
-        /// The entities to be updated
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        IEnumerable<TEntity> UpdateRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="IEnumerable{TEntity}"/> and <see cref="{TPrimaryKey}"/>. This method performs update operation for EasyBaseEntity. In additional this method returs <see cref="Task{TResult}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entities">
-        /// The entites to be updated
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="Task{TResult}"/>
-        /// </returns>
-        Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> performs replace operation. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be replaced
-        /// </param>
-        TEntity Replace<TEntity>(TEntity entity) where TEntity : class;
-
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and <see cref="CancellationToken"/> performs replace operation async version. In additional this methods returns <see cref="Task{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be replaced
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="Task"/>
-        /// </returns>
-        Task<TEntity> ReplaceAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and <see cref="{TPrimaryKey}"/>. This method performs replace operation for EasyBaseEntity. In additional this method returs <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be replaced
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity Replace<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-        /// <summary>
-        /// This method takes <see cref="{TEntity}"/> and <see cref="{TPrimaryKey}"/>. This method performs replace operation for EasyBaseEntity. In additional this method returs <see cref="Task{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TPrimaryKey">
-        /// Type of Primary Key
-        /// </typeparam>
-        /// <param name="entity">
-        /// The entity to be replaced
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="Task{TEntity}"/>
-        /// </returns>
-        Task<TEntity> ReplaceAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>;
-
-
-        /// <summary>
-        /// This method provides entity queryable version. In additional this method returns <see cref="IQueryable{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <returns>
-        /// Returns <see cref="IQueryable{TEntity}"/>
-        /// </returns>
-        IQueryable<TEntity> GetQueryable<TEntity>() where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{TDelegate}"/> and apply filter to data source. In additional returns <see cref="IQueryable{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="filter">
-        /// The filter to apply on the Entity.
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="IQueryable{TEntity}"/>
-        /// </returns>
-        IQueryable<TEntity> GetQueryable<TEntity>(Expression<Func<TEntity, bool>> filter) where TEntity : class;
-
-        /// <summary>
-        /// This method  returns List of Entity without filter. <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        List<TEntity> GetMultiple<TEntity>(bool asNoTracking) where TEntity : class;
-
-        /// <summary>
-        /// This method  returns List of Entity without filter async version. <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method provides without filter get all entity but you can convert it to any object you want.
-        /// In additional this method takes <see cref="Expression{Func}"/> returns <see cref="List{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="projectExpression">
-        /// Select expression
-        /// </param>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> and <see cref="CancellationToken"/>. This method performs without filter get all entity but you can convert it to any object you want
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="projectExpression">
-        /// Select expression
-        /// </param>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> performs apply filter get all entity. In additional returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="whereExpression">
-        /// Where expression see <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> and <see cref="CancellationToken"/>. This method performs apply filter get all entity. In additional returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="whereExpression">
-        /// Where Expression
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> where expression and <see cref="Expression{Func}"/> select expression. This method performs apply filter and convert returns get all entity. In additional returns <see cref="List{TPrtojected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of Projected object
-        /// </typeparam>
-        /// <param name="whereExpression">
-        /// Where Expression
-        /// </param>
-        /// <param name="projectExpression">
-        /// Select expression
-        /// </param>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> where expression and <see cref="Expression{Func}"/> select expression. This method performs apply filter async version and convert returns get all entity. In additional returns <see cref="List{TPrtojected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of Projected object
-        /// </typeparam>
-        /// <param name="whereExpression">
-        /// Where Expression
-        /// </param>
-        /// <param name="projectExpression">
-        /// Select expression
-        /// </param>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> and <see cref="IIncludableQueryable{TEntity, TProperty}"/>. This method performs get all with includable entities. In additional this method returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// <see cref="IIncludableQueryable{TEntity, TProperty}"/> expression
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> and <see cref="IIncludableQueryable{TEntity, TProperty}"/>. This method performs get all with includable entities async version. In additional this method returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// <see cref="IIncludableQueryable{TEntity, TProperty}"/> expression
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/>, <see cref="Expression{Func}"/> and <see cref="IIncludableQueryable{TEntity, TProperty}"/>. This method perform get all entities with filter and includable entities. In additional this method returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where Expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/>, <see cref="Expression{Func}"/>, <see cref="IIncludableQueryable{TEntity, TProperty}"/> and <see cref="CancellationToken"/>. This method perform get all entities with filter and includable entities async version. In additional this method returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where Expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> where expression, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression and <see cref="Expression{Func}"/> select expression. This method perform get all projected object with filter and include entities. In additional returns <see cref="List{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where Expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Select expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> where expression, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression, <see cref="Expression{Func}"/> select expression and <see cref="CancellationToken"/> cancellation token. This method perform get all projected object with filter and include entities async version. In additional returns <see cref="List{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where Expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Select expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/> pagination filter object. This method performs generate LINQ expressions for Entities over DTOs automatically. In additional returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/> pagination filter object and <see cref="CancellationToken"/>. This method performs generate LINQ expressions for Entities over DTOs automatically async version. In additional returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/>  pagination filter object and <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression. This method performs get all entities with apply filter and includable entities. In additional returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter Object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/> paginationable filter object, <see cref="IIncludableQueryable{TEntity, TProperty}"/> and <see cref="CancellationToken"/> cancellation token. This method performs get all entities with apply filter and get all includable entities async version. In additional this method returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/> paginationable filter object and <see cref="Expression{Func}"/> project expression. This method performs get all projected objects with apply filter. In additional returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter Object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/> paginationable filter object and <see cref="Expression{Func}"/> project expression. This method performs get all projected objects with apply filter async version. In additional returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter Object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TProjected}"/>
-        /// </returns>
-        Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/> paginationable filter object, <see cref="Expression{Func}"/> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression. This method performs get all projected objects with apply filter and get all includable entities. In additional this method returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="{TFilter}"/> paginationable filter object, <see cref="Expression{Func}"/> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression. This method performs get all projected objects with apply filter and get all includable entities async version. In additional this method returns <see cref="List{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter dto <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="List{TEntity}"/>
-        /// </returns>
-        Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking and <see cref="Expression{Func}"/> where expression. This method performs get entity with apply filter. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking and <see cref="Expression{Func}"/> where expression. This method performs get entity with apply filter async version. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> and <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression. This method performs get entity with apply filter and includable entities. In additional this method returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> and <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression. This method performs get entity with apply filter and includable entities async version. In additional this method returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> where expression and <see cref="Expression{Func}"/> project the expression. This method performs get projected object with apply filter. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> where expression, <see cref="Expression{Func}"/> project the expression and <see cref="CancellationToken"/> cancellation token. This method performs get projected object with apply filter async version. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> where expression, <see cref="Expression{Func}"/> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression. This method performs get projected object with apply filter and includable entity. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class;
-
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> where expression, <see cref="Expression{Func}"/> project expression, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression and <see cref="CancellationToken"/> cancellation token. This method performs get projected object with apply filter and includable entity async version. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking and <see cref="{TFilter}"/> filter object. This object must be type <see cref="FilterBase"/>. This method perform get entity with filter. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="CancellationToken"/> cancellation token and <see cref="{TFilter}"/> filter object. This object must be type <see cref="FilterBase"/>. This method perform get entity with filter async version. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression and <see cref="{TFilter}"/> filterable object <see cref="FilterBase"/>. This method performs get and includable entity with filter. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression, <see cref="CancellationToken"/> cancellation token and <see cref="{TFilter}"/> filterable object <see cref="FilterBase"/>. This method performs get and includable entity with filter. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> select expression and <see cref="{TFilter}"/> filterable object <see cref="FilterBase"/>. This method performs get projected object with filter. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> select expression, <see cref="CancellationToken"/> cancellation token and <see cref="{TFilter}"/> filterable object <see cref="FilterBase"/>. This method performs get projected object with filter. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> select expression, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression and <see cref="{TFilter}"/> filterable object <see cref="FilterBase"/>. This method performs get projected object with filter. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="Expression{Func}"/> select expression, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression, <see cref="CancellationToken"/> cancellation token and <see cref="{TFilter}"/> filterable object <see cref="FilterBase"/>. This method performs get projected object with filter. In additional returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of Filter <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="filter">
-        /// Filter object of type FilterBase <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking and <see cref="object"/> id. This method provides get entity by id. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity GetById<TEntity>(bool asNoTracking, object id) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="object"/> id. This method provides get entity by id async version. In additional returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="object"/> id and <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression. This method performs get entity by id with includable entities. In additional this method returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asnoTracking">
-        /// Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asNoTracking, <see cref="object"/> id, <see cref="IIncludableQueryable{TEntity, TProperty}"/> include expression and <see cref="CancellationToken"/> cancellation token. This method performs get entity by id with includable entities. In additional this method returns <see cref="{TEntity}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TEntity}"/>
-        /// </returns>
-        Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asnoTracking, <see cref="object"/> id and <see cref="Expression{Func}"/> project expression. This method performs get projected object by id with includable entities. In additional this method returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asnoTracking, <see cref="object"/> id and <see cref="Expression{Func}"/> project expression. This method performs get projected object by id with includable entities async version. In additional this method returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asnoTracking, <see cref="object"/> id, <see cref="IIncludableQueryable{TEntity, TProperty}"/> and <see cref="Expression{Func}"/> project expression. This method performs get projected object by id with includable entities. In additional this method returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="bool"/> asnoTracking, <see cref="object"/> id, <see cref="IIncludableQueryable{TEntity, TProperty}"/> and <see cref="Expression{Func}"/> project expression. This method performs get projected object by id with includable entities async version. In additional this method returns <see cref="{TProjected}"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <typeparam name="TProjected">
-        /// Type of projected object <see cref="{TProjected}"/>
-        /// </typeparam>
-        /// <param name="asNoTracking">
-        /// Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool"/>
-        /// </param>
-        /// <param name="id">
-        /// PK of entity
-        /// </param>
-        /// <param name="includeExpression">
-        /// Include expression <see cref="IIncludableQueryable{TEntity, TProperty}"/>
-        /// </param>
-        /// <param name="projectExpression">
-        /// Project expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="{TProjected}"/>
-        /// </returns>
-        Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> any expression. This method perform exist operation for condition. In additional returns <see cref="bool"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="anyExpression">
-        /// Any expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="bool"/>
-        /// </returns>
-        bool Any<TEntity>(Expression<Func<TEntity, bool>> anyExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> any expression and <see cref="CancellationToken"/> cancellation token. This method perform exist operation for condition. In additional returns <see cref="bool"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="anyExpression">
-        /// Any expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="bool"/>
-        /// </returns>
-        Task<bool> AnyAsync<TEntity>(Expression<Func<TEntity, bool>> anyExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-
-        /// <summary>
-        /// This method performs get count information of entity. In additional returns <see cref="int"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <returns>
-        /// Returns <see cref="int"/>
-        /// </returns>
-        int Count<TEntity>() where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="CancellationToken"/> cancellation token.This method performs get count information of entity async version. In additional returns <see cref="int"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <returns>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// Returns <see cref="int"/>
-        /// </returns>
-        Task<int> CountAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/>. This method performs get count information of entity with filter. In additional returns <see cref="int"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="int"/>
-        /// </returns>
-        int Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression) where TEntity : class;
-
-        /// <summary>
-        /// This method takes <see cref="Expression{Func}"/> and <see cref="CancellationToken"/> cancellation token. This method performs get count information of entity with filter async version. In additional returns <see cref="int"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of entity
-        /// </typeparam>
-        /// <param name="whereExpression">
-        /// Where expression <see cref="Expression{Func}"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="int"/>
-        /// </returns>
-        Task<int> Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class;
-
-
-        /// <summary>
-        /// This method takes <see cref="{TFilter}"/> filterable object. This object must be inheritance <see cref="FilterBase"/>. This method performs get count information of entity with filter. In additional <see cref="int"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filterable object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="filter">
-        /// Filterable object <see cref="FilterBase"/>
-        /// </param>
-        /// <returns>
-        /// Returns <see cref="int"/>
-        /// </returns>
-        int Count<TEntity, TFilter>(TFilter filter) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method takes <see cref="CancellationToken"/> cancellation token and <see cref="{TFilter}"/> filterable object. This object must be inheritance <see cref="FilterBase"/>. This method performs get count information of entity with filter async version. In additional <see cref="int"/>
-        /// </summary>
-        /// <typeparam name="TEntity">
-        /// Type of Entity
-        /// </typeparam>
-        /// <typeparam name="TFilter">
-        /// Type of filterable object <see cref="FilterBase"/>
-        /// </typeparam>
-        /// <param name="filter">
-        /// Filterable object <see cref="FilterBase"/>
-        /// </param>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Returns <see cref="int"/>
-        /// </returns>
-        Task<int> CountAsync<TEntity, TFilter>(TFilter filter, CancellationToken cancellationToken = default) where TEntity : class where TFilter : FilterBase;
-
-        /// <summary>
-        /// This method provides save changes for changes in current transaction
-        /// </summary>
-        void Complete();
-        
-        /// <summary>
-        /// This method takes <see cref="CancellationToken"/> cancellation token in additional this method provides save changes for changes in current transactions
-        /// </summary>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        /// Task. <see cref="Task"/>
-        /// </returns>
-        Task CompleteAsync(CancellationToken cancellationToken = default);
-    }
+    /// <typeparam name="TEntity">
+    ///     Type of Entity <see cref="{TEntity}" />
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be added
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity Add<TEntity>(TEntity entity)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="EasyBaseEntity{TPrimaryKey}" /> and performs entity insert operation. In additional
+    ///     this methods returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of entity primary key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be added
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity Add<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and performs entity insert async. In additional this methods returns
+    ///     <see cref="Task{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity <see cref="{TEntity}" />
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be added
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task{TEntity}" />
+    /// </returns>
+    Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="EasyBaseEntity{TPrimaryKey}" /> and performs entity insert operation async version. In
+    ///     additional this methods returns <see cref="Task{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of entity primary key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be added
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns></returns>
+    Task<TEntity> AddAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This methods takes <see cref="IEnumerable{TEntity}" /> and performs entity insert range operation. In additional
+    ///     this methods returns <see cref="IEnumerable{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="entities">
+    ///     The entity to be added
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="IEnumerable{TEntity}" />
+    /// </returns>
+    IEnumerable<TEntity> AddRange<TEntity>(IEnumerable<TEntity> entities)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="IEnumerable{EasyBaseEntity{TPrimaryKey}}" /> and performs entity insert range
+    ///     operation. In additional this methods returns <see cref="IEnumerable{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entities">
+    ///     The entities to be added
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="IEnumerable{TEntity}" />
+    /// </returns>
+    IEnumerable<TEntity> AddRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="IEnumerable{TEntity}" /> and performs entity insert range operation async version. In
+    ///     additional this methods returns <see cref="IEnumerable{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="entities">
+    ///     The entities to be added
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task{IEnumerable{TEntity}}" />
+    /// </returns>
+    Task<IEnumerable<TEntity>> AddRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="IEnumerable{EasyBaseEntity{TPrimaryKey}}" /> and performs entity insert range
+    ///     operation. In additional this methods returns <see cref="Task{IEnumerable{TEntity}}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of primary key
+    /// </typeparam>
+    /// <param name="entites">
+    ///     The entities to be added
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task{IEnumerable{TEntity}}" />
+    /// </returns>
+    Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entites, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> any expression. This method perform exist operation for
+    ///     condition. In additional returns <see cref="bool" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="anyExpression">
+    ///     Any expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="bool" />
+    /// </returns>
+    bool Any<TEntity>(Expression<Func<TEntity, bool>> anyExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> any expression and <see cref="CancellationToken" /> cancellation
+    ///     token. This method perform exist operation for condition. In additional returns <see cref="bool" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="anyExpression">
+    ///     Any expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="bool" />
+    /// </returns>
+    Task<bool> AnyAsync<TEntity>(Expression<Func<TEntity, bool>> anyExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method provides save changes for changes in current transaction
+    /// </summary>
+    void Complete();
+
+    /// <summary>
+    ///     This method takes <see cref="CancellationToken" /> cancellation token in additional this method provides save
+    ///     changes for changes in current transactions
+    /// </summary>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Task. <see cref="Task" />
+    /// </returns>
+    Task CompleteAsync(CancellationToken cancellationToken = default);
+
+
+    /// <summary>
+    ///     This method performs get count information of entity. In additional returns <see cref="int" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <returns>
+    ///     Returns <see cref="int" />
+    /// </returns>
+    int Count<TEntity>()
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" />. This method performs get count information of entity with
+    ///     filter. In additional returns <see cref="int" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="int" />
+    /// </returns>
+    int Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" /> cancellation token. This
+    ///     method performs get count information of entity with filter async version. In additional returns <see cref="int" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="int" />
+    /// </returns>
+    Task<int> Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+
+    /// <summary>
+    ///     This method takes <see cref="{TFilter}" /> filterable object. This object must be inheritance
+    ///     <see cref="FilterBase" />. This method performs get count information of entity with filter. In additional
+    ///     <see cref="int" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filterable object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="filter">
+    ///     Filterable object <see cref="FilterBase" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="int" />
+    /// </returns>
+    int Count<TEntity, TFilter>(TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="CancellationToken" /> cancellation token.This method performs get count information of
+    ///     entity async version. In additional returns <see cref="int" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <returns>
+    ///     <param name="cancellationToken">
+    ///         A <see cref="CancellationToken" /> to observe while waiting for the task to
+    ///         complete.
+    ///     </param>
+    ///     Returns <see cref="int" />
+    /// </returns>
+    Task<int> CountAsync<TEntity>(CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="CancellationToken" /> cancellation token and <see cref="{TFilter}" /> filterable
+    ///     object. This object must be inheritance <see cref="FilterBase" />. This method performs get count information of
+    ///     entity with filter async version. In additional <see cref="int" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filterable object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="filter">
+    ///     Filterable object <see cref="FilterBase" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="int" />
+    /// </returns>
+    Task<int> CountAsync<TEntity, TFilter>(TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="object" /> id. This method provides get entity by
+    ///     id. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetById<TEntity>(bool asNoTracking, object id)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity by id
+    ///     with includable entities. In additional this method returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asnoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
+    ///     project expression. This method performs get projected object by id with includable entities. In additional this
+    ///     method returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
+    ///     This method performs get projected object by id with includable entities. In additional this method returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetById<TEntity, TProjected>(
+        bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id. This method provides get entity by id
+    ///     async version. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="object" /> id,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="CancellationToken" />
+    ///     cancellation token. This method performs get entity by id with includable entities. In additional this method
+    ///     returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetByIdAsync<TEntity>(
+        bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id and <see cref="Expression{Func}" />
+    ///     project expression. This method performs get projected object by id with includable entities async version. In
+    ///     additional this method returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetByIdAsync<TEntity, TProjected>(
+        bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asnoTracking, <see cref="object" /> id,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="Expression{Func}" /> project expression.
+    ///     This method performs get projected object by id with includable entities async version. In additional this method
+    ///     returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by the EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="id">
+    ///     PK of entity
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetByIdAsync<TEntity, TProjected>(
+        bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method  returns List of Entity without filter. <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(bool asNoTracking)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method provides without filter get all entity but you can convert it to any object you want.
+    ///     In additional this method takes <see cref="Expression{Func}" /> returns <see cref="List{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> performs apply filter get all entity. In additional returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where expression see <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> where expression and <see cref="Expression{Func}" /> select
+    ///     expression. This method performs apply filter and convert returns get all entity. In additional returns
+    ///     <see cref="List{TPrtojected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of Projected object
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where Expression
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> and <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method
+    ///     performs get all with includable entities. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> expression
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" />, <see cref="Expression{Func}" /> and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method perform get all entities with filter and
+    ///     includable entities. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="Expression{Func}" />
+    ///     select expression. This method perform get all projected object with filter and include entities. In additional
+    ///     returns <see cref="List{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object. This method
+    ///     performs generate LINQ expressions for Entities over DTOs automatically. In additional returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" />  pagination filter object and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get all entities
+    ///     with apply filter and includable entities. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter Object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
+    ///     <see cref="Expression{Func}" /> project expression. This method performs get all projected objects with apply
+    ///     filter. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter Object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
+    ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    ///     include expression. This method performs get all projected objects with apply filter and get all includable
+    ///     entities. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method  returns List of Entity without filter async version. <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" />. This method performs
+    ///     without filter get all entity but you can convert it to any object you want
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> and <see cref="CancellationToken" />. This method performs apply
+    ///     filter get all entity. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where Expression
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{Func}" /> where expression and <see cref="Expression{Func}" /> select
+    ///     expression. This method performs apply filter async version and convert returns get all entity. In additional
+    ///     returns <see cref="List{TPrtojected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of Projected object
+    /// </typeparam>
+    /// <param name="whereExpression">
+    ///     Where Expression
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression
+    /// </param>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> and <see cref="IIncludableQueryable{TEntity, TProperty}" />. This method
+    ///     performs get all with includable entities async version. In additional this method returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> expression
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" />, <see cref="Expression{Func}" />,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="CancellationToken" />. This method perform
+    ///     get all entities with filter and includable entities async version. In additional this method returns
+    ///     <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression, <see cref="Expression{Func}" /> select
+    ///     expression and <see cref="CancellationToken" /> cancellation token. This method perform get all projected object
+    ///     with filter and include entities async version. In additional returns <see cref="List{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where Expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Select expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> pagination filter object and
+    ///     <see cref="CancellationToken" />. This method performs generate LINQ expressions for Entities over DTOs
+    ///     automatically async version. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> and <see cref="CancellationToken" /> cancellation token.
+    ///     This method performs get all entities with apply filter and get all includable entities async version. In
+    ///     additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(
+        bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object and
+    ///     <see cref="Expression{Func}" /> project expression. This method performs get all projected objects with apply
+    ///     filter async version. In additional returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter Object <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TProjected}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="{TFilter}" /> paginationable filter object,
+    ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    ///     include expression. This method performs get all projected objects with apply filter and get all includable
+    ///     entities async version. In additional this method returns <see cref="List{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter dto <see cref="FilterBase" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="List{TEntity}" />
+    /// </returns>
+    Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+
+    /// <summary>
+    ///     This method provides entity queryable version. In additional this method returns <see cref="IQueryable{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <returns>
+    ///     Returns <see cref="IQueryable{TEntity}" />
+    /// </returns>
+    IQueryable<TEntity> GetQueryable<TEntity>()
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Expression{TDelegate}" /> and apply filter to data source. In additional returns
+    ///     <see cref="IQueryable{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="filter">
+    ///     The filter to apply on the Entity.
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="IQueryable{TEntity}" />
+    /// </returns>
+    IQueryable<TEntity> GetQueryable<TEntity>(Expression<Func<TEntity, bool>> filter)
+        where TEntity : class;
+
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="Expression{Func}" /> where expression. This
+    ///     method performs get entity with apply filter. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
+    ///     apply filter and includable entities. In additional this method returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression and
+    ///     <see cref="Expression{Func}" /> project the expression. This method performs get projected object with apply
+    ///     filter. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="Expression{Func}" /> project expression and <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    ///     include expression. This method performs get projected object with apply filter and includable entity. In
+    ///     additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="{TFilter}" /> filter object. This object must be
+    ///     type <see cref="FilterBase" />. This method perform get entity with filter. In additional returns
+    ///     <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
+    ///     expression and <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs get and
+    ///     includable entity with filter. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression and
+    ///     <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs get projected object
+    ///     with filter. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression and <see cref="{TFilter}" /> filterable
+    ///     object <see cref="FilterBase" />. This method performs get projected object with filter. In additional returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    TProjected GetSingle<TEntity, TProjected, TFilter>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking and <see cref="Expression{Func}" /> where expression. This
+    ///     method performs get entity with apply filter async version. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> and
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression. This method performs get entity with
+    ///     apply filter and includable entities async version. In additional this method returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="Expression{Func}" /> project the expression and <see cref="CancellationToken" /> cancellation token.
+    ///     This method performs get projected object with apply filter async version. In additional returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> where expression,
+    ///     <see cref="Expression{Func}" /> project expression, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
+    ///     expression and <see cref="CancellationToken" /> cancellation token. This method performs get projected object with
+    ///     apply filter and includable entity async version. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TProjected">
+    ///     Type of projected object <see cref="{TProjected}" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="whereExpression">
+    ///     Where expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="projectExpression">
+    ///     Project expression <see cref="Expression{Func}" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="CancellationToken" /> cancellation token and
+    ///     <see cref="{TFilter}" /> filter object. This object must be type <see cref="FilterBase" />. This method perform get
+    ///     entity with filter async version. In additional returns <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="IIncludableQueryable{TEntity, TProperty}" /> include
+    ///     expression, <see cref="CancellationToken" /> cancellation token and <see cref="{TFilter}" /> filterable object
+    ///     <see cref="FilterBase" />. This method performs get and includable entity with filter. In additional returns
+    ///     <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    Task<TEntity> GetSingleAsync<TEntity, TFilter>(
+        bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
+    ///     <see cref="CancellationToken" /> cancellation token and <see cref="{TFilter}" /> filterable object
+    ///     <see cref="FilterBase" />. This method performs get projected object with filter. In additional returns
+    ///     <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="bool" /> asNoTracking, <see cref="Expression{Func}" /> select expression,
+    ///     <see cref="IIncludableQueryable{TEntity, TProperty}" /> include expression, <see cref="CancellationToken" />
+    ///     cancellation token and <see cref="{TFilter}" /> filterable object <see cref="FilterBase" />. This method performs
+    ///     get projected object with filter. In additional returns <see cref="{TProjected}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TFilter">
+    ///     Type of Filter <see cref="FilterBase" />
+    /// </typeparam>
+    /// <param name="asNoTracking">
+    ///     Do you want the entity to be tracked by EF Core? Default value : false <see cref="bool" />
+    /// </param>
+    /// <param name="filter">
+    ///     Filter object of type FilterBase <see cref="FilterBase" />
+    /// </param>
+    /// <param name="includeExpression">
+    ///     Include expression <see cref="IIncludableQueryable{TEntity, TProperty}" />
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="{TProjected}" />
+    /// </returns>
+    Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and performs entity hard delete operation.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be deleted
+    /// </param>
+    void HardDelete<TEntity>(TEntity entity)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Object" /> and performs entity hard delete operation
+    /// </summary>
+    /// <param name="id">
+    ///     PK of Entity
+    /// </param>
+    void HardDelete<TEntity>(object id)
+        where TEntity : class;
+
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and performs hard delete operation
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key for Entity
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be deleted
+    /// </param>
+    void HardDelete<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TPrimaryKey}" /> and performs hard delete operation by id.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="id">
+    ///     PK of Entity
+    /// </param>
+    void HardDelete<TEntity, TPrimaryKey>(TPrimaryKey id)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and <see cref="CancellationToken" />. This method performs entity hard
+    ///     delete operation. In additional this methods returns <see cref="Task" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be deleted
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task HardDeleteAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="Object" /> an <see cref="CancellationToken" />. This method performs hard delete
+    ///     operation async version. In additional returns <see cref="Task" />
+    /// </summary>
+    /// <param name="id">
+    ///     Pk of Entity
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task HardDeleteAsync<TEntity>(object id, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and performs hard delete operation async version for EasyBaseEntity. In
+    ///     additional this method returns <see cref="Task" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be deleted
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task HardDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TPrimaryKey}" /> and <see cref="CancellationToken" />. This method performs hard
+    ///     delete operation by id async version. In additional this method returns <see cref="Task" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="id">
+    ///     PK of Entity
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task HardDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> performs replace operation. In additional returns
+    ///     <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be replaced
+    /// </param>
+    TEntity Replace<TEntity>(TEntity entity)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs replace operation
+    ///     for EasyBaseEntity. In additional this method returs <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be replaced
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity Replace<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and <see cref="CancellationToken" /> performs replace operation async
+    ///     version. In additional this methods returns <see cref="Task{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be replaced
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task<TEntity> ReplaceAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs replace operation
+    ///     for EasyBaseEntity. In additional this method returs <see cref="Task{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be replaced
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="Task{TEntity}" />
+    /// </returns>
+    Task<TEntity> ReplaceAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+
+    /// <summary>
+    ///     This method takes <see cref="{TPrimaryKey}" /> and performs soft delete operation
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="id">
+    ///     PK of Entity
+    /// </param>
+    void SoftDelete<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TPrimaryKey}" /> and performs soft delete operation by id.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="id">
+    ///     PK of Entity
+    /// </param>
+    void SoftDelete<TEntity, TPrimaryKey>(TPrimaryKey id)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> performs soft delete operation. In additional this method returns
+    ///     <see cref="Task" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be deleted
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task SoftDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TPrimaryKey}" /> and <see cref="CancellationToken" />. This method performs soft
+    ///     delete operation by id async version. In additional this method returns <see cref="Task" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="id">
+    ///     PK of Entity
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task SoftDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> performs update operation. In additional returns
+    ///     <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be updated
+    /// </param>
+    TEntity Update<TEntity>(TEntity entity)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update operation
+    ///     for EasyBaseEntity. In additional this method returs <see cref="{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be updated
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    TEntity Update<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and <see cref="CancellationToken" /> performs update operation async
+    ///     version. In additional this methods returns <see cref="Task{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be updated
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task" />
+    /// </returns>
+    Task<TEntity> UpdateAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update operation
+    ///     for EasyBaseEntity. In additional this method returs <see cref="Task{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entity">
+    ///     The entity to be updated
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="Task{TEntity}" />
+    /// </returns>
+    Task<TEntity> UpdateAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="IEnumerable{TEntity}" /> performs update operation. In additional returns
+    ///     <see cref="IEnumerable{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="entities">
+    ///     The entities to be updated
+    /// </param>
+    IEnumerable<TEntity> UpdateRange<TEntity>(IEnumerable<TEntity> entities)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="IEnumerable{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update
+    ///     range operation for EasyBaseEntity. In additional this method returs <see cref="IEnumerable{TEntity}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entities">
+    ///     The entities to be updated
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="{TEntity}" />
+    /// </returns>
+    IEnumerable<TEntity> UpdateRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
+
+    /// <summary>
+    ///     This method takes <see cref="IEnumerable{TEntity}" /> and <see cref="CancellationToken" /> performs update
+    ///     operation async version. In additional this methods returns <see cref="Task{TResult}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <param name="entities">
+    ///     The entities to be updated
+    /// </param>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     Returns <see cref="Task{TResult}" />
+    /// </returns>
+    Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+        where TEntity : class;
+
+    /// <summary>
+    ///     This method takes <see cref="IEnumerable{TEntity}" /> and <see cref="{TPrimaryKey}" />. This method performs update
+    ///     operation for EasyBaseEntity. In additional this method returs <see cref="Task{TResult}" />
+    /// </summary>
+    /// <typeparam name="TEntity">
+    ///     Type of Entity
+    /// </typeparam>
+    /// <typeparam name="TPrimaryKey">
+    ///     Type of Primary Key
+    /// </typeparam>
+    /// <param name="entities">
+    ///     The entites to be updated
+    /// </param>
+    /// <returns>
+    ///     Returns <see cref="Task{TResult}" />
+    /// </returns>
+    Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>;
 }

--- a/src/EasyRepository.EFCore.Ardalis.Specification/SpecificationConverter.cs
+++ b/src/EasyRepository.EFCore.Ardalis.Specification/SpecificationConverter.cs
@@ -1,30 +1,31 @@
-﻿using System.Linq;
-using Ardalis.Specification;
-using Ardalis.Specification.EntityFrameworkCore;
+﻿namespace EasyRepository.EFCore.Ardalis.Specification;
 
-namespace EasyRepository.EFCore.Ardalis.Specification;
+using System.Linq;
+using global::Ardalis.Specification;
+using global::Ardalis.Specification.EntityFrameworkCore;
 
 /// <summary>
-/// Specification Builder
+///     Specification Builder
 /// </summary>
 public static class SpecificationConverter
 {
     /// <summary>
-    /// This method convert specification object to queryable object.
+    ///     This method convert specification object to queryable object.
     /// </summary>
     /// <param name="entity">
-    /// Entity
+    ///     Entity
     /// </param>
     /// <param name="specification">
-    /// Specification object
+    ///     Specification object
     /// </param>
     /// <typeparam name="TEntity">
-    /// Entity
+    ///     Entity
     /// </typeparam>
     /// <returns>
-    /// <see cref="IQueryable{TEntity}"/>
+    ///     <see cref="IQueryable{TEntity}" />
     /// </returns>
-    public static IQueryable<TEntity> Convert<TEntity>(IQueryable<TEntity> entity, ISpecification<TEntity> specification) where TEntity : class
+    public static IQueryable<TEntity> Convert<TEntity>(IQueryable<TEntity> entity, ISpecification<TEntity> specification)
+        where TEntity : class
     {
         return SpecificationEvaluator.Default.GetQuery(entity, specification);
     }

--- a/src/EasyRepository.EFCore.Generic/EasyRepository.EFCore.Generic.csproj
+++ b/src/EasyRepository.EFCore.Generic/EasyRepository.EFCore.Generic.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\common.props"/>
+    <Import Project="..\..\common.props" />
     <PropertyGroup>
         <PackageIcon>folders.png</PackageIcon>
-        <PackageIconUrl/>
+        <PackageIconUrl />
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="..\EasyRepository.EFCore.Abstractions\EasyRepository.EFCore.Abstractions.csproj"/>
+        <ProjectReference Include="..\EasyRepository.EFCore.Abstractions\EasyRepository.EFCore.Abstractions.csproj" />
     </ItemGroup>
     <ItemGroup>
         <None Include="folders.png">

--- a/src/EasyRepository.EFCore.Generic/EasyRepository.EFCore.Generic.csproj
+++ b/src/EasyRepository.EFCore.Generic/EasyRepository.EFCore.Generic.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
     <PropertyGroup>
         <PackageIcon>folders.png</PackageIcon>
-        <PackageIconUrl />
+        <PackageIconUrl/>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="..\EasyRepository.EFCore.Abstractions\EasyRepository.EFCore.Abstractions.csproj" />
+        <ProjectReference Include="..\EasyRepository.EFCore.Abstractions\EasyRepository.EFCore.Abstractions.csproj"/>
     </ItemGroup>
     <ItemGroup>
         <None Include="folders.png">

--- a/src/EasyRepository.EFCore.Generic/Extensions/EfTrackingOptionExtensions.cs
+++ b/src/EasyRepository.EFCore.Generic/Extensions/EfTrackingOptionExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace EasyRepository.EFCore.Generic.Extensions;
+
+using Abstractions.Enums;
+
+internal static class EfTrackingOptionExtensions
+{
+    public static bool HasNoTracking(this EfTrackingOptions options)
+    {
+        return options == EfTrackingOptions.AsNoTracking;
+    }
+}

--- a/src/EasyRepository.EFCore.Generic/IUnitOfWork.cs
+++ b/src/EasyRepository.EFCore.Generic/IUnitOfWork.cs
@@ -1,9 +1,9 @@
-﻿using EasyRepository.EFCore.Abstractions;
+﻿namespace EasyRepository.EFCore.Generic;
 
-namespace EasyRepository.EFCore.Generic;
+using Abstractions;
 
 /// <summary>
-/// Abstraction of Unit Of Work pattern
+///     Abstraction of Unit Of Work pattern
 /// </summary>
 public interface IUnitOfWork
 {

--- a/src/EasyRepository.EFCore.Generic/Repository.cs
+++ b/src/EasyRepository.EFCore.Generic/Repository.cs
@@ -491,6 +491,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TEntity> GetMultiple<TEntity>(bool asNoTracking)
         where TEntity : class
     {
@@ -521,6 +522,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default)
         where TEntity : class
     {
@@ -538,6 +540,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
     {
@@ -555,6 +558,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
         where TEntity : class
     {
@@ -575,6 +579,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
         where TEntity : class
     {
@@ -592,6 +597,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
         where TEntity : class
     {
@@ -611,6 +617,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
     {
@@ -630,6 +637,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
@@ -655,6 +663,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
     {
@@ -674,6 +683,7 @@ internal sealed class Repository : IRepository
         return queryable.ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TEntity>> GetMultipleAsync<TEntity>(
         bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
         where TEntity : class
@@ -697,6 +707,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
     {
@@ -719,6 +730,7 @@ internal sealed class Repository : IRepository
         return queryable.ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TEntity>> GetMultipleAsync<TEntity>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
@@ -746,6 +758,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TProjected> GetMultiple<TEntity, TProjected>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression)
@@ -773,6 +786,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
@@ -802,6 +816,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
         where TEntity : class
         where TFilter : FilterBase
@@ -821,6 +836,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase
@@ -842,6 +858,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase
@@ -865,6 +882,7 @@ internal sealed class Repository : IRepository
         return queryable.ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(
         bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
@@ -894,6 +912,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
         where TFilter : FilterBase
@@ -915,6 +934,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
@@ -942,6 +962,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
@@ -956,6 +977,7 @@ internal sealed class Repository : IRepository
             .ToList();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
@@ -971,6 +993,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
         where TEntity : class
     {
@@ -1005,6 +1028,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TProjected GetSingle<TEntity, TProjected, TFilter>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
@@ -1019,6 +1043,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
         where TEntity : class
     {
@@ -1040,6 +1065,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
     {
@@ -1061,6 +1087,7 @@ internal sealed class Repository : IRepository
         return queryable.FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TEntity> GetSingleAsync<TEntity>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
@@ -1088,6 +1115,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
     {
@@ -1107,6 +1135,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
@@ -1132,6 +1161,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TProjected GetSingle<TEntity, TProjected>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
@@ -1159,6 +1189,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(
         bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
@@ -1188,6 +1219,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
         where TEntity : class
         where TFilter : FilterBase
@@ -1209,6 +1241,7 @@ internal sealed class Repository : IRepository
         return queryable.FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
         where TEntity : class
         where TFilter : FilterBase
@@ -1232,6 +1265,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
         where TFilter : FilterBase
@@ -1255,6 +1289,7 @@ internal sealed class Repository : IRepository
         return queryable.FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(
         bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
@@ -1284,6 +1319,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
         where TFilter : FilterBase
@@ -1307,6 +1343,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
@@ -1337,6 +1374,7 @@ internal sealed class Repository : IRepository
     }
 
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
         bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
@@ -1352,6 +1390,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TEntity GetById<TEntity>(bool asNoTracking, object id)
         where TEntity : class
     {
@@ -1384,6 +1423,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default)
         where TEntity : class
     {
@@ -1401,6 +1441,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
         where TEntity : class
     {
@@ -1422,6 +1463,7 @@ internal sealed class Repository : IRepository
         return queryable.FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TEntity> GetByIdAsync<TEntity>(
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         CancellationToken cancellationToken = default)
@@ -1449,6 +1491,7 @@ internal sealed class Repository : IRepository
             .ConfigureAwait(false);
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression)
         where TEntity : class
     {
@@ -1470,6 +1513,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefault();
     }
 
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(
         bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression,
         CancellationToken cancellationToken = default)
@@ -1496,7 +1540,7 @@ internal sealed class Repository : IRepository
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
     }
-
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public TProjected GetById<TEntity, TProjected>(
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression)
@@ -1509,7 +1553,7 @@ internal sealed class Repository : IRepository
         return queryable.Select(projectExpression)
             .FirstOrDefault();
     }
-
+    [Obsolete("The boolean option for 'asNoTracking' is obsolete. Please use the Enum.EfTrackingOptions method instead of the boolean version.")]
     public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(
         bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
         Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)

--- a/src/EasyRepository.EFCore.Generic/Repository.cs
+++ b/src/EasyRepository.EFCore.Generic/Repository.cs
@@ -1,8 +1,5 @@
-﻿using AutoFilterer.Extensions;
-using AutoFilterer.Types;
-using EasyRepository.EFCore.Abstractions;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
+﻿namespace EasyRepository.EFCore.Generic;
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,641 +7,981 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Storage;
+using Abstractions;
+using AutoFilterer.Extensions;
+using AutoFilterer.Types;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 
-namespace EasyRepository.EFCore.Generic
+/// <summary>
+///     This class contains implementations of repository functions
+/// </summary>
+internal sealed class Repository : IRepository
 {
+    private readonly DbContext _context;
+
     /// <summary>
-    /// This class contains implementations of repository functions
+    ///     Ctor
     /// </summary>
-    internal sealed class Repository : IRepository
+    /// <param name="context">
+    ///     Database Context <see cref="DbContext" />
+    /// </param>
+    public Repository(DbContext context)
     {
-        private readonly DbContext _context;
-
-        /// <summary>
-        /// Ctor
-        /// </summary>
-        /// <param name="context">
-        /// Database Context <see cref="DbContext"/>
-        /// </param>
-        public Repository(DbContext context)
-        {
-            this._context = context;
-        }
-
-        public TEntity Add<TEntity>(TEntity entity) where TEntity : class
-        {
-            _context.Set<TEntity>().Add(entity);
-            return entity;
-        }
-
-        public TEntity Add<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.CreationDate = DateTime.UtcNow;
-            _context.Set<TEntity>().Add(entity);
-            return entity;
-        }
-
-        public async Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            await _context.Set<TEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
-            return entity;
-        }
-
-        public async Task<TEntity> AddAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.CreationDate = DateTime.UtcNow;
-            await _context.Set<TEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
-            return entity;
-        }
-
-        public IEnumerable<TEntity> AddRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class
-        {
-            _context.Set<TEntity>().AddRange(entities);
-            return entities;
-        }
-
-        public IEnumerable<TEntity> AddRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entities.ToList().ForEach(x => x.CreationDate = DateTime.UtcNow);
-            _context.Set<TEntity>().AddRange(entities);
-            return entities;
-        }
-
-        public async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            await _context.Set<TEntity>().AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
-            return entities;
-        }
-
-        public async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entities.ToList().ForEach(x => x.CreationDate = DateTime.UtcNow);
-            await _context.Set<TEntity>().AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
-            return entities;
-        }
-
-        public bool Any<TEntity>(Expression<Func<TEntity, bool>> anyExpression) where TEntity : class
-        {
-            return _context.Set<TEntity>().Any(anyExpression);
-        }
-
-        public async Task<bool> AnyAsync<TEntity>(Expression<Func<TEntity, bool>> anyExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            bool result = await _context.Set<TEntity>().AnyAsync(anyExpression, cancellationToken).ConfigureAwait(false);
-            return result;
-        }
-
-        public int Count<TEntity>() where TEntity : class
-        {
-            return _context.Set<TEntity>().Count();
-        }
-
-        public int Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression) where TEntity : class
-        {
-            return _context.Set<TEntity>().Where(whereExpression).Count();
-        }
-
-        public async Task<int> Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            int count = await _context.Set<TEntity>().Where(whereExpression).CountAsync(cancellationToken).ConfigureAwait(false);
-            return count;
-        }
-
-        public int Count<TEntity, TFilter>(TFilter filter)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            return _context.Set<TEntity>().ApplyFilter(filter).Count();
-        }
-
-        public async Task<int> CountAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class
-        {
-            int count = await _context.Set<TEntity>().CountAsync(cancellationToken).ConfigureAwait(false);
-            return count;
-        }
-
-        public async Task<int> CountAsync<TEntity, TFilter>(TFilter filter, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            int count = await _context.Set<TEntity>().ApplyFilter(filter).CountAsync(cancellationToken).ConfigureAwait(false);
-            return count;
-        }
-
-        public void Complete()
-        {
-            _context.SaveChanges();
-        }
-
-        public async Task CompleteAsync(CancellationToken cancellationToken = default)
-        {
-            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        private Expression<Func<TEntity, bool>> GenerateExpression<TEntity>(object id)
-        {
-            var type = _context.Model.FindEntityType(typeof(TEntity));
-            string pk = type.FindPrimaryKey().Properties.Select(s => s.Name).FirstOrDefault();
-            Type pkType = type.FindPrimaryKey().Properties.Select(p => p.ClrType).FirstOrDefault();
-
-            object value = Convert.ChangeType(id, pkType, CultureInfo.InvariantCulture);
-
-            ParameterExpression pe = Expression.Parameter(typeof(TEntity), "entity");
-            MemberExpression me = Expression.Property(pe, pk);
-            ConstantExpression constant = Expression.Constant(value, pkType);
-            BinaryExpression body = Expression.Equal(me, constant);
-            Expression<Func<TEntity, bool>> expression = Expression.Lambda<Func<TEntity, bool>>(body, new[] { pe });
-
-            return expression;
-        }
-
-        public void HardDelete<TEntity>(TEntity entity) where TEntity : class
-        {
-            _context.Set<TEntity>().Remove(entity);
-        }
-
-        public void HardDelete<TEntity>(object id) where TEntity : class
-        {
-            var entity = _context.Set<TEntity>().Find(id);
-            _context.Set<TEntity>().Remove(entity);
-        }
-
-        public void HardDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            _context.Set<TEntity>().Remove(entity);
-        }
-
-        public void HardDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            var entity = _context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
-            _context.Set<TEntity>().Remove(entity);
-        }
-
-        public Task HardDeleteAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            _context.Set<TEntity>().Remove(entity);
-            return Task.CompletedTask;
-        }
-
-        public async Task HardDeleteAsync<TEntity>(object id, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var entity = await _context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
-            _context.Set<TEntity>().Remove(entity);
-        }
-
-        public Task HardDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            _context.Set<TEntity>().Remove(entity);
-            return Task.CompletedTask;
-        }
-
-        public async Task HardDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            var entity = await _context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
-            _context.Set<TEntity>().Remove(entity);
-        }
-
-        public TEntity Replace<TEntity>(TEntity entity) where TEntity : class
-        {
-            _context.Entry(entity).State = EntityState.Modified;
-            return entity;
-        }
-
-        public TEntity Replace<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.ModificationDate = DateTime.UtcNow;
-            _context.Entry(entity).State = EntityState.Modified;
-            return entity;
-        }
-
-        public Task<TEntity> ReplaceAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            _context.Entry(entity).State = EntityState.Modified;
-            return Task.FromResult(entity);
-        }
-
-        public Task<TEntity> ReplaceAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.ModificationDate = DateTime.UtcNow;
-            _context.Entry(entity).State = EntityState.Modified;
-            return Task.FromResult(entity);
-        }
-
-        public void SoftDelete<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.IsDeleted = true;
-            entity.DeletionDate = DateTime.UtcNow;
-            Replace<TEntity, TPrimaryKey>(entity);
-        }
-
-        public void SoftDelete<TEntity, TPrimaryKey>(TPrimaryKey id) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            var entity = _context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
-            entity.IsDeleted = true;
-            entity.DeletionDate = DateTime.UtcNow;
-            Replace<TEntity, TPrimaryKey>(entity);
-        }
-
-        public async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.IsDeleted = true;
-            entity.DeletionDate = DateTime.UtcNow;
-            await ReplaceAsync<TEntity, TPrimaryKey>(entity, cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            var entity = await _context.Set<TEntity>().FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false); ;
-            entity.IsDeleted = true;
-            entity.DeletionDate = DateTime.UtcNow;
-            await ReplaceAsync<TEntity, TPrimaryKey>(entity, cancellationToken).ConfigureAwait(false);
-        }
-
-        public TEntity Update<TEntity>(TEntity entity) where TEntity : class
-        {
-            _context.Set<TEntity>().Update(entity);
-            return entity;
-        }
-
-        public TEntity Update<TEntity, TPrimaryKey>(TEntity entity) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.ModificationDate = DateTime.UtcNow;
-            _context.Set<TEntity>().Update(entity);
-            return entity;
-        }
-
-        public Task<TEntity> UpdateAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            _context.Set<TEntity>().Update(entity);
-            return Task.FromResult(entity);
-        }
-
-        public Task<TEntity> UpdateAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entity.ModificationDate = DateTime.UtcNow;
-            _context.Set<TEntity>().Update(entity);
-            return Task.FromResult(entity);
-        }
-
-        public IEnumerable<TEntity> UpdateRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class
-        {
-            _context.Set<TEntity>().UpdateRange(entities);
-            return entities;
-        }
-
-        public IEnumerable<TEntity> UpdateRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entities.ToList().ForEach(a => a.ModificationDate = DateTime.UtcNow);
-            _context.Set<TEntity>().UpdateRange(entities);
-            return entities;
-        }
-
-        public async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            _context.Set<TEntity>().UpdateRange(entities);
-            return entities;
-        }
-
-        public async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) where TEntity : EasyBaseEntity<TPrimaryKey>
-        {
-            entities.ToList().ForEach(a => a.ModificationDate = DateTime.UtcNow);
-            _context.Set<TEntity>().UpdateRange(entities);
-            return entities;
-        }
-
-        public IQueryable<TEntity> GetQueryable<TEntity>() where TEntity : class
-        {
-            return _context.Set<TEntity>().AsQueryable();
-        }
-
-        public IQueryable<TEntity> GetQueryable<TEntity>(Expression<Func<TEntity, bool>> filter) where TEntity : class
-        {
-            return _context.Set<TEntity>().Where(filter);
-        }
-
-        private IQueryable<TEntity> FindQueryable<TEntity>(bool asNoTracking) where TEntity : class
-        {
-            var queryable = GetQueryable<TEntity>();
-            if (asNoTracking)
-            {
-                queryable = queryable.AsNoTracking();
-            }
-            return queryable;
-        }
-
-        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking) where TEntity : class
-        {
-            return FindQueryable<TEntity>(asNoTracking).ToList();
-        }
-
-        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            return await FindQueryable<TEntity>(asNoTracking).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class
-        {
-            return FindQueryable<TEntity>(asNoTracking).Select(projectExpression).ToList();
-        }
-
-        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            return await FindQueryable<TEntity>(asNoTracking).Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class
-        {
-            return FindQueryable<TEntity>(asNoTracking).Where(whereExpression).ToList();
-        }
-
-        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            return await FindQueryable<TEntity>(asNoTracking).Where(whereExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class
-        {
-            return FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).ToList();
-        }
-
-        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            return await FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking);
-            queryable = includeExpression(queryable);
-            return queryable.ToList();
-        }
-
-        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking);
-            queryable = includeExpression(queryable);
-            return await queryable.ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return queryable.ToList();
-        }
-
-        public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return await queryable.ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return queryable.Select(projectExpression).ToList();
-        }
-
-        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return await queryable.Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            return FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).ToList();
-        }
-
-        public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            return await FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return queryable.ToList();
-        }
-
-        public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return await queryable.ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            return FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).Select(projectExpression).ToList();
-        }
-
-        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            return await FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter).Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return queryable.Select(projectExpression).ToList();
-        }
-
-        public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return await queryable.Select(projectExpression).ToListAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            return queryable.FirstOrDefault();
-        }
-
-        public async Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return queryable.FirstOrDefault();
-        }
-
-        public async Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class
-        {
-            return FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).FirstOrDefault();
-        }
-
-        public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            return await FindQueryable<TEntity>(asNoTracking).Where(whereExpression).Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return queryable.Select(projectExpression).FirstOrDefault();
-        }
-
-        public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(whereExpression);
-            queryable = includeExpression(queryable);
-            return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            return queryable.FirstOrDefault();
-        }
-
-        public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return queryable.FirstOrDefault();
-        }
-
-        public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            return queryable.Select(projectExpression).FirstOrDefault();
-        }
-
-        public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return queryable.Select(projectExpression).FirstOrDefault();
-        }
-
-        public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
-            where TEntity : class
-            where TFilter : FilterBase
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).ApplyFilter(filter);
-            queryable = includeExpression(queryable);
-            return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TEntity GetById<TEntity>(bool asNoTracking, object id) where TEntity : class
-        {
-            return _context.Set<TEntity>().FirstOrDefault(GenerateExpression<TEntity>(id));
-        }
-
-        public async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            return await FindQueryable<TEntity>(asNoTracking).FirstOrDefaultAsync(GenerateExpression<TEntity>(id), cancellationToken).ConfigureAwait(false);
-        }
-
-        public TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
-            queryable = includeExpression(queryable);
-            return queryable.FirstOrDefault();
-        }
-
-        public async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
-            queryable = includeExpression(queryable);
-            return await queryable.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
-            return queryable.Select(projectExpression).FirstOrDefault();
-        }
-
-        public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
-            return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        public TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
-            queryable = includeExpression(queryable);
-            return queryable.Select(projectExpression).FirstOrDefault();
-        }
-
-        public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default) where TEntity : class
-        {
-            var queryable = FindQueryable<TEntity>(asNoTracking).Where(GenerateExpression<TEntity>(id));
-            queryable = includeExpression(queryable);
-            return await queryable.Select(projectExpression).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-        }
+        this._context = context;
+    }
+
+    public TEntity Add<TEntity>(TEntity entity)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .Add(entity);
+
+        return entity;
+    }
+
+    public TEntity Add<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.CreationDate = DateTime.UtcNow;
+        this._context.Set<TEntity>()
+            .Add(entity);
+
+        return entity;
+    }
+
+    public async Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        await this._context.Set<TEntity>()
+            .AddAsync(entity, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity;
+    }
+
+    public async Task<TEntity> AddAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.CreationDate = DateTime.UtcNow;
+        await this._context.Set<TEntity>()
+            .AddAsync(entity, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity;
+    }
+
+    public IEnumerable<TEntity> AddRange<TEntity>(IEnumerable<TEntity> entities)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .AddRange(entities);
+
+        return entities;
+    }
+
+    public IEnumerable<TEntity> AddRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entities.ToList()
+            .ForEach(x => x.CreationDate = DateTime.UtcNow);
+        this._context.Set<TEntity>()
+            .AddRange(entities);
+
+        return entities;
+    }
+
+    public async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        await this._context.Set<TEntity>()
+            .AddRangeAsync(entities, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities;
+    }
+
+    public async Task<IEnumerable<TEntity>> AddRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entities.ToList()
+            .ForEach(x => x.CreationDate = DateTime.UtcNow);
+        await this._context.Set<TEntity>()
+            .AddRangeAsync(entities, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities;
+    }
+
+    public bool Any<TEntity>(Expression<Func<TEntity, bool>> anyExpression)
+        where TEntity : class
+    {
+        return this._context.Set<TEntity>()
+            .Any(anyExpression);
+    }
+
+    public async Task<bool> AnyAsync<TEntity>(Expression<Func<TEntity, bool>> anyExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var result = await this._context.Set<TEntity>()
+            .AnyAsync(anyExpression, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result;
+    }
+
+    public int Count<TEntity>()
+        where TEntity : class
+    {
+        return this._context.Set<TEntity>()
+            .Count();
+    }
+
+    public int Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class
+    {
+        return this._context.Set<TEntity>()
+            .Where(whereExpression)
+            .Count();
+    }
+
+    public async Task<int> Count<TEntity>(Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var count = await this._context.Set<TEntity>()
+            .Where(whereExpression)
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return count;
+    }
+
+    public int Count<TEntity, TFilter>(TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        return this._context.Set<TEntity>()
+            .ApplyFilter(filter)
+            .Count();
+    }
+
+    public async Task<int> CountAsync<TEntity>(CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var count = await this._context.Set<TEntity>()
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return count;
+    }
+
+    public async Task<int> CountAsync<TEntity, TFilter>(TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var count = await this._context.Set<TEntity>()
+            .ApplyFilter(filter)
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return count;
+    }
+
+    public void Complete()
+    {
+        this._context.SaveChanges();
+    }
+
+    public async Task CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        await this._context.SaveChangesAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public void HardDelete<TEntity>(TEntity entity)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .Remove(entity);
+    }
+
+    public void HardDelete<TEntity>(object id)
+        where TEntity : class
+    {
+        var entity = this._context.Set<TEntity>()
+            .Find(id);
+        this._context.Set<TEntity>()
+            .Remove(entity);
+    }
+
+    public void HardDelete<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        this._context.Set<TEntity>()
+            .Remove(entity);
+    }
+
+    public void HardDelete<TEntity, TPrimaryKey>(TPrimaryKey id)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        var entity = this._context.Set<TEntity>()
+            .FirstOrDefault(this.GenerateExpression<TEntity>(id));
+        this._context.Set<TEntity>()
+            .Remove(entity);
+    }
+
+    public Task HardDeleteAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .Remove(entity);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task HardDeleteAsync<TEntity>(object id, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var entity = await this._context.Set<TEntity>()
+            .FirstOrDefaultAsync(this.GenerateExpression<TEntity>(id), cancellationToken)
+            .ConfigureAwait(false);
+        this._context.Set<TEntity>()
+            .Remove(entity);
+    }
+
+    public Task HardDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        this._context.Set<TEntity>()
+            .Remove(entity);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task HardDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        var entity = await this._context.Set<TEntity>()
+            .FirstOrDefaultAsync(this.GenerateExpression<TEntity>(id), cancellationToken)
+            .ConfigureAwait(false);
+        this._context.Set<TEntity>()
+            .Remove(entity);
+    }
+
+    public TEntity Replace<TEntity>(TEntity entity)
+        where TEntity : class
+    {
+        this._context.Entry(entity)
+            .State = EntityState.Modified;
+
+        return entity;
+    }
+
+    public TEntity Replace<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.ModificationDate = DateTime.UtcNow;
+        this._context.Entry(entity)
+            .State = EntityState.Modified;
+
+        return entity;
+    }
+
+    public Task<TEntity> ReplaceAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        this._context.Entry(entity)
+            .State = EntityState.Modified;
+
+        return Task.FromResult(entity);
+    }
+
+    public Task<TEntity> ReplaceAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.ModificationDate = DateTime.UtcNow;
+        this._context.Entry(entity)
+            .State = EntityState.Modified;
+
+        return Task.FromResult(entity);
+    }
+
+    public void SoftDelete<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.IsDeleted = true;
+        entity.DeletionDate = DateTime.UtcNow;
+        this.Replace<TEntity, TPrimaryKey>(entity);
+    }
+
+    public void SoftDelete<TEntity, TPrimaryKey>(TPrimaryKey id)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        var entity = this._context.Set<TEntity>()
+            .FirstOrDefault(this.GenerateExpression<TEntity>(id));
+        entity.IsDeleted = true;
+        entity.DeletionDate = DateTime.UtcNow;
+        this.Replace<TEntity, TPrimaryKey>(entity);
+    }
+
+    public async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.IsDeleted = true;
+        entity.DeletionDate = DateTime.UtcNow;
+        await this.ReplaceAsync<TEntity, TPrimaryKey>(entity, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task SoftDeleteAsync<TEntity, TPrimaryKey>(TPrimaryKey id, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        var entity = await this._context.Set<TEntity>()
+            .FirstOrDefaultAsync(this.GenerateExpression<TEntity>(id), cancellationToken)
+            .ConfigureAwait(false);
+        ;
+        entity.IsDeleted = true;
+        entity.DeletionDate = DateTime.UtcNow;
+        await this.ReplaceAsync<TEntity, TPrimaryKey>(entity, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TEntity Update<TEntity>(TEntity entity)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .Update(entity);
+
+        return entity;
+    }
+
+    public TEntity Update<TEntity, TPrimaryKey>(TEntity entity)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.ModificationDate = DateTime.UtcNow;
+        this._context.Set<TEntity>()
+            .Update(entity);
+
+        return entity;
+    }
+
+    public Task<TEntity> UpdateAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .Update(entity);
+
+        return Task.FromResult(entity);
+    }
+
+    public Task<TEntity> UpdateAsync<TEntity, TPrimaryKey>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entity.ModificationDate = DateTime.UtcNow;
+        this._context.Set<TEntity>()
+            .Update(entity);
+
+        return Task.FromResult(entity);
+    }
+
+    public IEnumerable<TEntity> UpdateRange<TEntity>(IEnumerable<TEntity> entities)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .UpdateRange(entities);
+
+        return entities;
+    }
+
+    public IEnumerable<TEntity> UpdateRange<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entities.ToList()
+            .ForEach(a => a.ModificationDate = DateTime.UtcNow);
+        this._context.Set<TEntity>()
+            .UpdateRange(entities);
+
+        return entities;
+    }
+
+    public async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        this._context.Set<TEntity>()
+            .UpdateRange(entities);
+
+        return entities;
+    }
+
+    public async Task<IEnumerable<TEntity>> UpdateRangeAsync<TEntity, TPrimaryKey>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+        where TEntity : EasyBaseEntity<TPrimaryKey>
+    {
+        entities.ToList()
+            .ForEach(a => a.ModificationDate = DateTime.UtcNow);
+        this._context.Set<TEntity>()
+            .UpdateRange(entities);
+
+        return entities;
+    }
+
+    public IQueryable<TEntity> GetQueryable<TEntity>()
+        where TEntity : class
+    {
+        return this._context.Set<TEntity>()
+            .AsQueryable();
+    }
+
+    public IQueryable<TEntity> GetQueryable<TEntity>(Expression<Func<TEntity, bool>> filter)
+        where TEntity : class
+    {
+        return this._context.Set<TEntity>()
+            .Where(filter);
+    }
+
+    public List<TEntity> GetMultiple<TEntity>(bool asNoTracking)
+        where TEntity : class
+    {
+        return this.FindQueryable<TEntity>(asNoTracking)
+            .ToList();
+    }
+
+    public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+    {
+        return this.FindQueryable<TEntity>(asNoTracking)
+            .Select(projectExpression)
+            .ToList();
+    }
+
+    public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .Select(projectExpression)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class
+    {
+        return this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression)
+            .ToList();
+    }
+
+    public async Task<List<TEntity>> GetMultipleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TProjected> GetMultiple<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+    {
+        return this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression)
+            .Select(projectExpression)
+            .ToList();
+    }
+
+    public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression)
+            .Select(projectExpression)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking);
+        queryable = includeExpression(queryable);
+
+        return queryable.ToList();
+    }
+
+    public async Task<List<TEntity>> GetMultipleAsync<TEntity>(
+        bool asNoTracking, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking);
+        queryable = includeExpression(queryable);
+
+        return await queryable.ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TEntity> GetMultiple<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return queryable.ToList();
+    }
+
+    public async Task<List<TEntity>> GetMultipleAsync<TEntity>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return await queryable.ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TProjected> GetMultiple<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return queryable.Select(projectExpression)
+            .ToList();
+    }
+
+    public async Task<List<TProjected>> GetMultipleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return await queryable.Select(projectExpression)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        return this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter)
+            .ToList();
+    }
+
+    public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TEntity> GetMultiple<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return queryable.ToList();
+    }
+
+    public async Task<List<TEntity>> GetMultipleAsync<TEntity, TFilter>(
+        bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return await queryable.ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        return this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter)
+            .Select(projectExpression)
+            .ToList();
+    }
+
+    public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter)
+            .Select(projectExpression)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public List<TProjected> GetMultiple<TEntity, TFilter, TProjected>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return queryable.Select(projectExpression)
+            .ToList();
+    }
+
+    public async Task<List<TProjected>> GetMultipleAsync<TEntity, TFilter, TProjected>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return await queryable.Select(projectExpression)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+
+        return queryable.FirstOrDefault();
+    }
+
+    public async Task<TEntity> GetSingleAsync<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+
+        return await queryable.FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TEntity GetSingle<TEntity>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return queryable.FirstOrDefault();
+    }
+
+    public async Task<TEntity> GetSingleAsync<TEntity>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return await queryable.FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TProjected GetSingle<TEntity, TProjected>(bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+    {
+        return this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression)
+            .Select(projectExpression)
+            .FirstOrDefault();
+    }
+
+    public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression)
+            .Select(projectExpression)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TProjected GetSingle<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return queryable.Select(projectExpression)
+            .FirstOrDefault();
+    }
+
+    public async Task<TProjected> GetSingleAsync<TEntity, TProjected>(
+        bool asNoTracking, Expression<Func<TEntity, bool>> whereExpression, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(whereExpression);
+        queryable = includeExpression(queryable);
+
+        return await queryable.Select(projectExpression)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+
+        return queryable.FirstOrDefault();
+    }
+
+    public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(bool asNoTracking, TFilter filter, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+
+        return await queryable.FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TEntity GetSingle<TEntity, TFilter>(bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return queryable.FirstOrDefault();
+    }
+
+    public async Task<TEntity> GetSingleAsync<TEntity, TFilter>(
+        bool asNoTracking, TFilter filter, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return await queryable.FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TProjected GetSingle<TEntity, TProjected, TFilter>(bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+
+        return queryable.Select(projectExpression)
+            .FirstOrDefault();
+    }
+
+    public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+
+        return await queryable.Select(projectExpression)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TProjected GetSingle<TEntity, TProjected, TFilter>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return queryable.Select(projectExpression)
+            .FirstOrDefault();
+    }
+
+    public async Task<TProjected> GetSingleAsync<TEntity, TProjected, TFilter>(
+        bool asNoTracking, TFilter filter, Expression<Func<TEntity, TProjected>> projectExpression,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+        where TFilter : FilterBase
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .ApplyFilter(filter);
+        queryable = includeExpression(queryable);
+
+        return await queryable.Select(projectExpression)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TEntity GetById<TEntity>(bool asNoTracking, object id)
+        where TEntity : class
+    {
+        return this._context.Set<TEntity>()
+            .FirstOrDefault(this.GenerateExpression<TEntity>(id));
+    }
+
+    public async Task<TEntity> GetByIdAsync<TEntity>(bool asNoTracking, object id, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        return await this.FindQueryable<TEntity>(asNoTracking)
+            .FirstOrDefaultAsync(this.GenerateExpression<TEntity>(id), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TEntity GetById<TEntity>(bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(this.GenerateExpression<TEntity>(id));
+        queryable = includeExpression(queryable);
+
+        return queryable.FirstOrDefault();
+    }
+
+    public async Task<TEntity> GetByIdAsync<TEntity>(
+        bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(this.GenerateExpression<TEntity>(id));
+        queryable = includeExpression(queryable);
+
+        return await queryable.FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TProjected GetById<TEntity, TProjected>(bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(this.GenerateExpression<TEntity>(id));
+
+        return queryable.Select(projectExpression)
+            .FirstOrDefault();
+    }
+
+    public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(
+        bool asNoTracking, object id, Expression<Func<TEntity, TProjected>> projectExpression,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(this.GenerateExpression<TEntity>(id));
+
+        return await queryable.Select(projectExpression)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public TProjected GetById<TEntity, TProjected>(
+        bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(this.GenerateExpression<TEntity>(id));
+        queryable = includeExpression(queryable);
+
+        return queryable.Select(projectExpression)
+            .FirstOrDefault();
+    }
+
+    public async Task<TProjected> GetByIdAsync<TEntity, TProjected>(
+        bool asNoTracking, object id, Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> includeExpression,
+        Expression<Func<TEntity, TProjected>> projectExpression, CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        var queryable = this.FindQueryable<TEntity>(asNoTracking)
+            .Where(this.GenerateExpression<TEntity>(id));
+        queryable = includeExpression(queryable);
+
+        return await queryable.Select(projectExpression)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private IQueryable<TEntity> FindQueryable<TEntity>(bool asNoTracking)
+        where TEntity : class
+    {
+        var queryable = this.GetQueryable<TEntity>();
+        if (asNoTracking)
+        {
+            queryable = queryable.AsNoTracking();
+        }
+
+        return queryable;
+    }
+
+    private Expression<Func<TEntity, bool>> GenerateExpression<TEntity>(object id)
+    {
+        var type = this._context.Model.FindEntityType(typeof(TEntity));
+        var pk = type.FindPrimaryKey()
+            .Properties.Select(s => s.Name)
+            .FirstOrDefault();
+        var pkType = type.FindPrimaryKey()
+            .Properties.Select(p => p.ClrType)
+            .FirstOrDefault();
+
+        var value = Convert.ChangeType(id, pkType, CultureInfo.InvariantCulture);
+
+        var pe = Expression.Parameter(typeof(TEntity), "entity");
+        var me = Expression.Property(pe, pk);
+        var constant = Expression.Constant(value, pkType);
+        var body = Expression.Equal(me, constant);
+        var expression = Expression.Lambda<Func<TEntity, bool>>(body, pe);
+
+        return expression;
     }
 }

--- a/src/EasyRepository.EFCore.Generic/Startup.cs
+++ b/src/EasyRepository.EFCore.Generic/Startup.cs
@@ -1,50 +1,55 @@
-﻿using EasyRepository.EFCore.Abstractions;
+﻿namespace EasyRepository.EFCore.Generic;
+
+using Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace EasyRepository.EFCore.Generic
+/// <summary>
+///     This class includes Service Collection extensions
+/// </summary>
+public static class Startup
 {
     /// <summary>
-    /// This class includes Service Collection extensions
+    ///     This method takes <see cref="ServiceLifetime" /> service lifetime and <see cref="{TDbContext}" /> database context.
+    ///     In additional this method performs apply easy repository library for own db context
     /// </summary>
-    public static class Startup
+    /// <typeparam name="TDbContext">
+    ///     <see cref="DbContext" /> database context.
+    /// </typeparam>
+    /// <param name="services">
+    ///     Service collection <see cref="IServiceCollection" />
+    /// </param>
+    /// <param name="serviceLifetime">
+    ///     Service LifeTime <see cref="ServiceLifetime" />
+    /// </param>
+    /// <returns>
+    ///     <see cref="IServiceCollection" />
+    /// </returns>
+    public static IServiceCollection ApplyEasyRepository<TDbContext>(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+        where TDbContext : DbContext
     {
-        /// <summary>
-        /// This method takes <see cref="ServiceLifetime"/> service lifetime and <see cref="{TDbContext}"/> database context. In additional this method performs apply easy repository library for own db context
-        /// </summary>
-        /// <typeparam name="TDbContext">
-        /// <see cref="DbContext"/> database context.
-        /// </typeparam>
-        /// <param name="services">
-        /// Service collection <see cref="IServiceCollection"/>
-        /// </param>
-        /// <param name="serviceLifetime">
-        /// Service LifeTime <see cref="ServiceLifetime"/>
-        /// </param>
-        /// <returns>
-        /// <see cref="IServiceCollection"/>
-        /// </returns>
-        public static IServiceCollection ApplyEasyRepository<TDbContext>(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Transient) where TDbContext : DbContext
-        {
-            services.Add(new ServiceDescriptor(
+        services.Add(
+            new ServiceDescriptor(
                 typeof(IRepository),
                 serviceProvider =>
                 {
                     var dbContext = ActivatorUtilities.CreateInstance<TDbContext>(serviceProvider);
+
                     return new Repository(dbContext);
                 },
                 serviceLifetime));
-            
-            services.Add(new ServiceDescriptor(
+
+        services.Add(
+            new ServiceDescriptor(
                 typeof(IUnitOfWork),
                 serviceProvider =>
                 {
                     var repository = serviceProvider.GetService<IRepository>();
+
                     return new UnitOfWork(repository);
                 },
                 serviceLifetime));
-            return services;
-        }
+
+        return services;
     }
 }

--- a/src/EasyRepository.EFCore.Generic/UnitOfWork.cs
+++ b/src/EasyRepository.EFCore.Generic/UnitOfWork.cs
@@ -1,15 +1,16 @@
-﻿using EasyRepository.EFCore.Abstractions;
+﻿namespace EasyRepository.EFCore.Generic;
 
-namespace EasyRepository.EFCore.Generic;
+using Abstractions;
 
 /// <summary>
-/// Implementation of Unit of work pattern
+///     Implementation of Unit of work pattern
 /// </summary>
 public class UnitOfWork : IUnitOfWork
 {
     public UnitOfWork(IRepository repository)
     {
-        Repository = repository;
+        this.Repository = repository;
     }
+
     public IRepository Repository { get; }
 }


### PR DESCRIPTION
## Summary

*** Summary is here ***

Changes made:

* Changed all files to 'file-scoped' namespaces
* Resharper automatically formatted the namespaces and using statements
* Added methods for Enum version of boolean as no tracking
* Added Obsolete messages
* Changed a typo of `async Task<int> Count(....)` to `async Task<int> CountAsync(....)`
* Changed the Enum version of the method:
* Changed **only the enum version of the method** GetById to use the `AsNoTracking` option. See below


````csharp

    public TEntity GetById<TEntity>(bool asNoTracking, object id)
        where TEntity : class
    {
        return this._context.Set<TEntity>()
            .FirstOrDefault(this.GenerateExpression<TEntity>(id));
    }

    /// <inheritdoc />
    public TEntity GetById<TEntity>(EfTrackingOptions asNoTracking, object id)
        where TEntity : class
    {
        var queryable = this.FindQueryable<TEntity>(asNoTracking)
            .FirstOrDefault(this.GenerateExpression<TEntity>(id));

        return queryable;
    }

````


![image](https://user-images.githubusercontent.com/12589359/193384116-48ddb546-536b-4c60-9039-4b43832a9c26.png)



If you want, I can also apply the change to the classic `boolean` `GetById<TEntity>(bool, object)` method.   I did not want to introduce any breaking changes, so I skipped this on the classic version.

