### PR TITLE
⬆️ [UPGRADE] Target framework has been upgraded

### DIFF
--- a/EasyRepository.EFCore.sln.DotSettings
+++ b/EasyRepository.EFCore.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=implemented/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/common.props
+++ b/common.props
@@ -3,18 +3,20 @@
 		<Title>Generic Repository Pattern For Entity Framework Core</Title>
 		<RepositoryType>Git</RepositoryType>
 		<NeutralLanguage>en-US</NeutralLanguage>
-		<TargetFrameworks>net6.0</TargetFrameworks>
-		<Version>2.0.0</Version>
+		<TargetFramework>net7.0</TargetFramework>
+		<Version>3.0.0</Version>
 		<LangVersion>latest</LangVersion>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<RepositoryUrl>https://github.com/furkandeveloper/EasyRepository.EFCore</RepositoryUrl>
 		<Authors>furkandeveloper</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<Description></Description>
+		<Description>
+			This repository provides generic repository pattern with Entity Framework Core
+		</Description>
 		<PackageTags>dotnet, efcore, repository-pattern, generic-repository, generic-repository-pattern</PackageTags>
 		<PackageReleaseNotes>
-			
+			Upgrade target framework from dotnet6 to dotnet7
 		</PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>

--- a/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
+++ b/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
@@ -7,7 +7,7 @@
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFilterer.Swagger" Version="2.12.2" />
+		<PackageReference Include="AutoFilterer.Swagger" Version="2.13.0" />
 		<PackageReference Include="AspNetCore.MarkdownDocumenting" Version="2.3.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">

--- a/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
+++ b/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
+++ b/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="AutoFilterer.Swagger" Version="2.13.0" />
 		<PackageReference Include="AspNetCore.MarkdownDocumenting" Version="2.3.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
+++ b/sample/EasyRepository.Sample/EasyRepository.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/EasyRepository.EFCore.Abstractions/EasyBaseEntity.cs
+++ b/src/EasyRepository.EFCore.Abstractions/EasyBaseEntity.cs
@@ -11,27 +11,37 @@ namespace EasyRepository.EFCore.Abstractions
     public abstract class EasyBaseEntity<TPrimaryKey> : IEasyEntity<TPrimaryKey>, IEasyCreateDateEntity, IEasyUpdateDateEntity, IEasySoftDeleteEntity
     {
         /// <summary>
-        /// Creation Date <see cref="{DateTime}"/>
+        /// Creation Date <see>
+        ///     <cref>{DateTime}</cref>
+        /// </see>
         /// </summary>
         public virtual DateTime CreationDate { get; set; }
 
         /// <summary>
-        /// Primary Key <see cref="{TPrimaryKey}"/>
+        /// Primary Key <see>
+        ///     <cref>{TPrimaryKey}</cref>
+        /// </see>
         /// </summary>
         public virtual TPrimaryKey Id { get; set; }
 
         /// <summary>
-        /// Modification Date <see cref="{DateTime}"/>
+        /// Modification Date <see>
+        ///     <cref>{DateTime}</cref>
+        /// </see>
         /// </summary>
         public virtual DateTime? ModificationDate { get; set; }
 
         /// <summary>
-        /// Deletion Date <see cref="{DateTime}"/>
+        /// Deletion Date <see>
+        ///     <cref>{DateTime}</cref>
+        /// </see>
         /// </summary>
         public virtual DateTime? DeletionDate { get; set; }
 
         /// <summary>
-        /// Is Deleted <see cref="{Boolean}"/>
+        /// Is Deleted <see>
+        ///     <cref>{Boolean}</cref>
+        /// </see>
         /// </summary>
         public virtual bool IsDeleted { get; set; }
     }

--- a/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
+++ b/src/EasyRepository.EFCore.Abstractions/EasyRepository.EFCore.Abstractions.csproj
@@ -7,8 +7,8 @@
 		<PackageIconUrl />
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="AutoFilterer" Version="2.12.2" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
+	  <PackageReference Include="AutoFilterer" Version="2.13.0" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Include="folders.png">


### PR DESCRIPTION
## Summary

This PR contains an upgraded target framework from `dotnet6` to `dotnet7`

## What?
`dotnet7` has been released in November. Therefore must upgrade all dependencies.

## Why?

Because third-party tools must support the latest version.

## How?

- Change target framework value.
- Upgrade all dependencies.
- Upgrade package version.
